### PR TITLE
adding dockerfile and documentation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git
+.github
+target/
+aether/target/
+quiche/target/
+**/.DS_Store
+aether.toml
+aether-masque.toml
+*-secondary.toml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM rust:1.88 AS builder
+
+RUN apt-get update && \
+    apt-get install -y \
+    clang \
+    cmake \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /usr/src/app
+
+COPY aether ./aether
+COPY quiche ./quiche
+
+WORKDIR /usr/src/app/aether
+RUN cargo build --release
+
+FROM gcr.io/distroless/cc-debian12
+
+WORKDIR /app
+
+COPY --from=builder /usr/src/app/aether/target/release/aether /usr/local/bin/aether
+
+ENV AETHER_SOCKS=0.0.0.0:1819
+
+ENTRYPOINT ["aether"]

--- a/Docs/GUIDE.en.md
+++ b/Docs/GUIDE.en.md
@@ -160,6 +160,19 @@ AETHER_PROTOCOL=wg AETHER_NOIZE=aggressive AETHER_SCAN=thorough ./target/release
 AETHER_PROTOCOL=gool AETHER_SOCKS=127.0.0.1:1080 ./target/release/aether
 ```
 
+### Running with Docker
+
+Docker provides an isolated environment and doesn't require installing Rust or any C++ compilers on your host machine.
+
+```bash
+docker build -t aether .
+docker run -it -p 1819:1819 \
+  -e AETHER_PROTOCOL=masque \
+  -e AETHER_SCAN=balanced \
+  aether
+```
+*(The `-it` flag is necessary for interactive prompts if you do not provide the environment variables beforehand.)*
+
 ## Testing whether it works
 
 As soon as it says the proxy is listening, run this:

--- a/Docs/GUIDE.fa.md
+++ b/Docs/GUIDE.fa.md
@@ -162,6 +162,19 @@ AETHER_PROTOCOL=wg AETHER_NOIZE=aggressive AETHER_SCAN=thorough ./target/release
 AETHER_PROTOCOL=gool AETHER_SOCKS=127.0.0.1:1080 ./target/release/aether
 ```
 
+### اجرا با داکر (Docker)
+
+داکر یه محیط ایزوله بهت می‌ده و نیازی به نصب Rust یا ابزارهای C++ روی سیستم خودت نداری.
+
+```bash
+docker build -t aether .
+docker run -it -p 1819:1819 \
+  -e AETHER_PROTOCOL=masque \
+  -e AETHER_SCAN=balanced \
+  aether
+```
+*(پرچم `-it` برای وقتی که متغیرهای محیطی رو از قبل ندادی و نیاز به پاسخ دادن به سؤالات تعاملی داری، ضروریه.)*
+
 ## تست اینکه واقعاً کار می‌کنه یا نه
 
 همین که برنامه گفت پراکسی در حال گوش‌دادنه، این دستور رو بزن:

--- a/README.fa.md
+++ b/README.fa.md
@@ -73,6 +73,31 @@ cargo build --release
 target/release/aether
 ```
 
+## داکر (Docker)
+
+شما می‌توانید Aether را در یک محیط ایزوله با استفاده از داکر بیلد و اجرا کنید.
+
+ساخت ایمیج:
+
+```bash
+docker build -t aether .
+```
+
+اجرای کانتینر (برای تنظیمات اولیه به حالت تعاملی نیاز است):
+
+```bash
+docker run -it -p 1819:1819 aether
+```
+
+همچنین می‌توانید با ارسال متغیرهای محیطی از پرسش‌های اولیه عبور کنید:
+
+```bash
+docker run -it -p 1819:1819 \
+  -e AETHER_PROTOCOL=masque \
+  -e AETHER_SCAN=balanced \
+  aether
+```
+
 ## اجرا
 
 برنامه را اجرا کنید:

--- a/README.md
+++ b/README.md
@@ -71,6 +71,31 @@ Binary:
 target/release/aether
 ```
 
+## Docker
+
+You can build and run Aether in an isolated environment using Docker.
+
+Build the image:
+
+```bash
+docker build -t aether .
+```
+
+Run the container (interactive mode is required for initial setup):
+
+```bash
+docker run -it -p 1819:1819 aether
+```
+
+You can also bypass prompts by providing environment variables:
+
+```bash
+docker run -it -p 1819:1819 \
+  -e AETHER_PROTOCOL=masque \
+  -e AETHER_SCAN=balanced \
+  aether
+```
+
 ## Usage
 
 Run:


### PR DESCRIPTION
Adding a multistage Dockerfile for a lightweight image along with the documentation needed to build and run the project as a docker container.

Adding an automated docker build pipeline further down the line would be a nice to have but isn't necessary.