### PR TITLE
Adding Docker Build stage to the Release actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -386,6 +386,9 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ghcr.io/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=tag
+            type=raw,value=latest
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -351,3 +351,46 @@ jobs:
                sha256sum -c aether-linux-x86_64.tar.gz.sha256
 
             See README.md and the Docs directory for transport selection, obfuscation profiles, the HTTP/2 vs HTTP/3 choice in MASQUE, and the full environment-variable reference.
+
+  # ------------------------------------------------------------------
+  # Build and push the Docker image to GitHub Container Registry (GHCR)
+  # ------------------------------------------------------------------
+  docker:
+    name: Build and push Docker image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Docker requires repository names to be strictly lowercase.
+      # Since CluvexStudio contains uppercase, we lowercase it here.
+      - name: Downcase repository name
+        run: |
+          echo "IMAGE_NAME=${GITHUB_REPOSITORY,,}" >> ${GITHUB_ENV}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Docs/GUIDE.en.md
+++ b/Docs/GUIDE.en.md
@@ -261,16 +261,22 @@ AETHER_QUICK_RECONNECT=1 ./target/release/aether --masque
 
 ### Running with Docker
 
-Docker provides an isolated environment and doesn't require installing Rust or any C++ compilers on your host machine.
+You can run the official Aether Docker image directly from the GitHub Container Registry (GHCR), which provides an isolated environment without needing to install Rust or C++ compilers.
 
 ```bash
-docker build -t aether .
 docker run -it -p 1819:1819 \
   -e AETHER_PROTOCOL=masque \
   -e AETHER_SCAN=balanced \
-  aether
+  ghcr.io/cluvexstudio/aether:latest
 ```
 *(The `-it` flag is necessary for interactive prompts if you do not provide the environment variables beforehand.)*
+
+If you prefer to build the image locally:
+
+```bash
+docker build -t aether .
+docker run -it -p 1819:1819 aether
+```
 
 ## Testing whether it works
 

--- a/Docs/GUIDE.fa.md
+++ b/Docs/GUIDE.fa.md
@@ -263,16 +263,22 @@ AETHER_QUICK_RECONNECT=1 ./target/release/aether --masque
 
 ### اجرا با داکر (Docker)
 
-داکر یه محیط ایزوله بهت می‌ده و نیازی به نصب Rust یا ابزارهای C++ روی سیستم خودت نداری.
+شما می‌توانید ایمیج رسمی Aether را مستقیماً از GitHub Container Registry (GHCR) اجرا کنید که یه محیط ایزوله بهت می‌ده و نیازی به نصب Rust یا ابزارهای C++ روی سیستم خودت نداری.
 
 ```bash
-docker build -t aether .
 docker run -it -p 1819:1819 \
   -e AETHER_PROTOCOL=masque \
   -e AETHER_SCAN=balanced \
-  aether
+  ghcr.io/cluvexstudio/aether:latest
 ```
 *(پرچم `-it` برای وقتی که متغیرهای محیطی رو از قبل ندادی و نیاز به پاسخ دادن به سؤالات تعاملی داری، ضروریه.)*
+
+در صورتی که ترجیح می‌دهید ایمیج را خودتان بیلد کنید:
+
+```bash
+docker build -t aether .
+docker run -it -p 1819:1819 aether
+```
 
 ## تست اینکه واقعاً کار می‌کنه یا نه
 

--- a/README.fa.md
+++ b/README.fa.md
@@ -76,18 +76,12 @@ target/release/aether
 
 ## داکر (Docker)
 
-شما می‌توانید Aether را در یک محیط ایزوله با استفاده از داکر بیلد و اجرا کنید.
+شما می‌توانید Aether را در یک محیط ایزوله با استفاده از داکر اجرا کنید. ایمیج رسمی برنامه روی GitHub Container Registry (GHCR) در دسترس است.
 
-ساخت ایمیج:
-
-```bash
-docker build -t aether .
-```
-
-اجرای کانتینر (برای تنظیمات اولیه به حالت تعاملی نیاز است):
+دریافت و اجرای ایمیج از پیش‌ساخته‌شده (برای تنظیمات اولیه به حالت تعاملی نیاز است):
 
 ```bash
-docker run -it -p 1819:1819 aether
+docker run -it -p 1819:1819 ghcr.io/cluvexstudio/aether:latest
 ```
 
 همچنین می‌توانید با ارسال متغیرهای محیطی از پرسش‌های اولیه عبور کنید:
@@ -96,7 +90,14 @@ docker run -it -p 1819:1819 aether
 docker run -it -p 1819:1819 \
   -e AETHER_PROTOCOL=masque \
   -e AETHER_SCAN=balanced \
-  aether
+  ghcr.io/cluvexstudio/aether:latest
+```
+
+در صورتی که ترجیح می‌دهید ایمیج را خودتان بیلد کنید:
+
+```bash
+docker build -t aether .
+docker run -it -p 1819:1819 aether
 ```
 
 ## اجرا

--- a/README.md
+++ b/README.md
@@ -74,18 +74,12 @@ target/release/aether
 
 ## Docker
 
-You can build and run Aether in an isolated environment using Docker.
+You can run Aether in an isolated environment using Docker. The official image is available on GitHub Container Registry (GHCR).
 
-Build the image:
-
-```bash
-docker build -t aether .
-```
-
-Run the container (interactive mode is required for initial setup):
+Pull and run the pre-built image (interactive mode is required for initial setup):
 
 ```bash
-docker run -it -p 1819:1819 aether
+docker run -it -p 1819:1819 ghcr.io/cluvexstudio/aether:latest
 ```
 
 You can also bypass prompts by providing environment variables:
@@ -94,7 +88,14 @@ You can also bypass prompts by providing environment variables:
 docker run -it -p 1819:1819 \
   -e AETHER_PROTOCOL=masque \
   -e AETHER_SCAN=balanced \
-  aether
+  ghcr.io/cluvexstudio/aether:latest
+```
+
+If you prefer to build the image manually from source:
+
+```bash
+docker build -t aether .
+docker run -it -p 1819:1819 aether
 ```
 
 ## Usage


### PR DESCRIPTION
Adding a docker build step to the release action which builds both the "latest" and the "tag"  version of the docker image on releases.

updating the documentation to reflect the fact that the user can use the pre-built images if they want to.