### PR TITLE
feat: add --version flag and print version at startup

### DIFF
--- a/aether/src/cli.rs
+++ b/aether/src/cli.rs
@@ -51,6 +51,7 @@ Config files:
 Advanced:
   --tls-groups <list>      TLS key share groups, e.g. \"P-256:X25519:P-384\"
 
+  -v, --version            show version and exit
   -h, --help               show this help and exit
 ";
 
@@ -71,6 +72,11 @@ pub fn parse_and_apply() -> crate::error::Result<()> {
         }
 
         match arg {
+            "-v" | "--version" => {
+                println!("aether {}", env!("CARGO_PKG_VERSION"));
+                std::process::exit(0);
+            }
+
             "-h" | "--help" => {
                 print!("{USAGE}");
                 std::process::exit(0);

--- a/aether/src/main.rs
+++ b/aether/src/main.rs
@@ -41,9 +41,9 @@ async fn main() -> Result<()> {
         .format_timestamp_millis()
         .init();
 
-    log::info!("Aether v{}", env!("CARGO_PKG_VERSION"));
-
     cli::parse_and_apply()?;
+
+    log::info!("Aether v{}", env!("CARGO_PKG_VERSION"));
 
     install_netstack_panic_guard();
 

--- a/aether/src/main.rs
+++ b/aether/src/main.rs
@@ -41,6 +41,8 @@ async fn main() -> Result<()> {
         .format_timestamp_millis()
         .init();
 
+    log::info!("Aether v{}", env!("CARGO_PKG_VERSION"));
+
     cli::parse_and_apply()?;
 
     install_netstack_panic_guard();


### PR DESCRIPTION
Closes #20.

Adds  and  CLI flags to print the application version and exit, updates help text, and logs the version on application startup.