### PR TITLE
fix: pre-allocate WG encapsulate/timer buffers outside hot loops

### DIFF
--- a/aether/src/wireguard.rs
+++ b/aether/src/wireguard.rs
@@ -161,9 +161,10 @@ impl WgTunnel {
         });
 
         let send_task = tokio::spawn(async move {
+            let mut out_buf = vec![0u8; MAX_PACKET]; // ponytail: reuse single buffer, not alloc-per-packet
+
             while let Some(ip_packet) = outbound_rx.recv().await {
                 let mut tunn = tunn_w.lock().await;
-                let mut out_buf = vec![0u8; MAX_PACKET];
 
                 match tunn.encapsulate(&ip_packet, &mut out_buf) {
                     TunnResult::Done => {}
@@ -201,10 +202,10 @@ impl WgTunnel {
 
         let timer_task = tokio::spawn(async move {
             let mut interval = tokio::time::interval(TIMER_TICK);
+            let mut tmp = vec![0u8; MAX_PACKET]; // ponytail: reuse single buffer, not alloc-per-tick
             loop {
                 interval.tick().await;
                 let mut tunn = tunn_t.lock().await;
-                let mut tmp = vec![0u8; MAX_PACKET];
                 if let TunnResult::WriteToNetwork(pkt) = tunn.update_timers(&mut tmp) {
                     let mut pkt_vec = pkt.to_vec();
                     inject_client_id(&mut pkt_vec, &client_id);


### PR DESCRIPTION
## Problem

In `wireguard.rs`, two `vec![0u8; MAX_PACKET]` (65KB each) allocations happen inside hot loops:

1. **Line 166** — `out_buf` inside `while let Some(ip_packet) = outbound_rx.recv().await` — allocates 65KB on **every outbound packet**
2. **Line 207** — `tmp` inside `loop { interval.tick().await; ... }` — allocates 65KB on **every 250ms timer tick**

On a router pushing traffic, this means thousands of 65KB allocations per second that are immediately dropped. On memory-constrained devices (128-512MB), this creates allocation churn that fragments the heap and drives RSS growth over time.

## Solution

Move both allocations before their respective loops so each buffer is allocated once and reused:

```rust
// BEFORE (per-packet):
while let Some(ip_packet) = outbound_rx.recv().await {
    let mut out_buf = vec![0u8; MAX_PACKET];  // 65KB every packet
    ...
}

// AFTER (once):
let mut out_buf = vec![0u8; MAX_PACKET];  // 65KB once
while let Some(ip_packet) = outbound_rx.recv().await {
    ...
}
```

Same pattern for the timer task's `tmp` buffer.

### Why it's safe

- `out_buf` is written to by `tunn.encapsulate()` which fills it from index 0 — stale data from a previous iteration is overwritten before being read
- `tmp` is written to by `tunn.update_timers()` which also fills from index 0
- The boringtunn API contract: callers provide a scratch buffer, the library writes into it and returns a slice of the written portion via `TunnResult::WriteToNetwork(pkt)` — it never reads pre-existing buffer contents

Fixes #24

## Test plan

- [ ] Run WireGuard tunnel under sustained traffic — RSS stays flat instead of growing
- [ ] Verify tunnel still passes data correctly (no stale buffer corruption)

🤖 Generated with [Claude Code](https://claude.com/claude-code)