### PR TITLE
perf: scale scan concurrency and buffer sizes to host CPU/RAM

### DIFF
--- a/aether/src/config.rs
+++ b/aether/src/config.rs
@@ -39,15 +39,24 @@ impl From<&Identity> for PersistedIdentity {
     }
 }
 
-impl From<PersistedIdentity> for Identity {
-    fn from(p: PersistedIdentity) -> Self {
+impl TryFrom<PersistedIdentity> for Identity {
+    type Error = AetherError;
+
+    fn try_from(p: PersistedIdentity) -> std::result::Result<Self, Self::Error> {
         let wg_priv = base64::engine::general_purpose::STANDARD
             .decode(&p.wg_private_key)
-            .expect("decode wg private key");
+            .map_err(|e| AetherError::Other(format!("corrupt config: wg private key: {e}")))?;
 
         let wg_peer = base64::engine::general_purpose::STANDARD
             .decode(&p.wg_peer_public_key)
-            .expect("decode wg peer public key");
+            .map_err(|e| AetherError::Other(format!("corrupt config: wg peer public key: {e}")))?;
+
+        if wg_priv.len() != 32 {
+            return Err(AetherError::Other(format!("corrupt config: wg private key length {}", wg_priv.len())));
+        }
+        if wg_peer.len() != 32 {
+            return Err(AetherError::Other(format!("corrupt config: wg peer public key length {}", wg_peer.len())));
+        }
 
         let mut wg_private_key = [0u8; 32];
         let mut wg_peer_public_key = [0u8; 32];
@@ -63,7 +72,7 @@ impl From<PersistedIdentity> for Identity {
             }
         }
 
-        Identity {
+        Ok(Identity {
             device_id: p.device_id,
             access_token: p.access_token,
             cert_pem: p.cert_pem.into_bytes(),
@@ -73,7 +82,7 @@ impl From<PersistedIdentity> for Identity {
             wg_private_key,
             wg_peer_public_key,
             client_id: client_id_arr,
-        }
+        })
     }
 }
 
@@ -84,7 +93,7 @@ pub fn load(path: &str) -> Result<Option<Identity>> {
     let text = std::fs::read_to_string(path)?;
     let persisted: PersistedIdentity =
         toml::from_str(&text).map_err(|e| AetherError::Other(format!("config parse: {e}")))?;
-    Ok(Some(persisted.into()))
+    Ok(Some(persisted.try_into()?))
 }
 
 pub fn save(path: &str, identity: &Identity) -> Result<()> {
@@ -92,6 +101,12 @@ pub fn save(path: &str, identity: &Identity) -> Result<()> {
     let text = toml::to_string_pretty(&persisted)
         .map_err(|e| AetherError::Other(format!("config encode: {e}")))?;
     std::fs::write(path, text)?;
+    // Config contains private keys — restrict to owner-only.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600));
+    }
     Ok(())
 }
 

--- a/aether/src/netstack.rs
+++ b/aether/src/netstack.rs
@@ -14,18 +14,21 @@ use crate::error::{AetherError, Result};
 /// Scale TCP/UDP buffers to available system memory.
 /// Desktop (16GB+): 512KB TCP, 128KB UDP.  Router (128-512MB): proportionally smaller.
 fn scaled_tcp_buf() -> usize {
-    let pages = unsafe { libc::sysconf(libc::_SC_PHYS_PAGES) };
-    let page_size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
-    if pages <= 0 || page_size <= 0 {
-        return 512 * 1024; // fallback to original
+    #[cfg(unix)]
+    {
+        let pages = unsafe { libc::sysconf(libc::_SC_PHYS_PAGES) };
+        let page_size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
+        if pages > 0 && page_size > 0 {
+            let total_mb = (pages as u64 * page_size as u64) / (1024 * 1024);
+            return match total_mb {
+                0..=256 => 64 * 1024,      // 128-256 MB: 64KB
+                257..=1024 => 128 * 1024,   // 256MB-1GB: 128KB
+                1025..=4096 => 256 * 1024,  // 1-4 GB: 256KB
+                _ => 512 * 1024,            // 4GB+: 512KB (original)
+            };
+        }
     }
-    let total_mb = (pages as u64 * page_size as u64) / (1024 * 1024);
-    match total_mb {
-        0..=256 => 64 * 1024,      // 128-256 MB: 64KB
-        257..=1024 => 128 * 1024,   // 256MB-1GB: 128KB
-        1025..=4096 => 256 * 1024,  // 1-4 GB: 256KB
-        _ => 512 * 1024,            // 4GB+: 512KB (original)
-    }
+    512 * 1024 // fallback for non-unix or sysconf failure
 }
 
 fn scaled_udp_buf() -> usize {

--- a/aether/src/netstack.rs
+++ b/aether/src/netstack.rs
@@ -11,8 +11,27 @@ use tokio::sync::{mpsc, oneshot};
 
 use crate::error::{AetherError, Result};
 
-const TCP_BUF: usize = 512 * 1024;
-const UDP_BUF: usize = 128 * 1024;
+/// Scale TCP/UDP buffers to available system memory.
+/// Desktop (16GB+): 512KB TCP, 128KB UDP.  Router (128-512MB): proportionally smaller.
+fn scaled_tcp_buf() -> usize {
+    let pages = unsafe { libc::sysconf(libc::_SC_PHYS_PAGES) };
+    let page_size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
+    if pages <= 0 || page_size <= 0 {
+        return 512 * 1024; // fallback to original
+    }
+    let total_mb = (pages as u64 * page_size as u64) / (1024 * 1024);
+    match total_mb {
+        0..=256 => 64 * 1024,      // 128-256 MB: 64KB
+        257..=1024 => 128 * 1024,   // 256MB-1GB: 128KB
+        1025..=4096 => 256 * 1024,  // 1-4 GB: 256KB
+        _ => 512 * 1024,            // 4GB+: 512KB (original)
+    }
+}
+
+fn scaled_udp_buf() -> usize {
+    scaled_tcp_buf() / 4
+}
+
 const UDP_META: usize = 128;
 const APP_QUEUE: usize = 4096;
 const MAX_INGEST_PER_TICK: usize = 512;
@@ -475,8 +494,8 @@ async fn sleep_opt(delay: Option<std::time::Duration>) {
 fn handle_cmd(s: &mut NetStack, cmd: Cmd) {
     match cmd {
         Cmd::OpenTcp { dst, resp } => {
-            let rx_buf = tcp::SocketBuffer::new(vec![0u8; TCP_BUF]);
-            let tx_buf = tcp::SocketBuffer::new(vec![0u8; TCP_BUF]);
+            let rx_buf = tcp::SocketBuffer::new(vec![0u8; scaled_tcp_buf()]);
+            let tx_buf = tcp::SocketBuffer::new(vec![0u8; scaled_tcp_buf()]);
             let mut socket = tcp::Socket::new(rx_buf, tx_buf);
             socket.set_nagle_enabled(false);
 
@@ -510,8 +529,8 @@ fn handle_cmd(s: &mut NetStack, cmd: Cmd) {
         Cmd::OpenUdp { resp } => {
             let rx_meta = vec![udp::PacketMetadata::EMPTY; UDP_META];
             let tx_meta = vec![udp::PacketMetadata::EMPTY; UDP_META];
-            let rx_buf = udp::PacketBuffer::new(rx_meta, vec![0u8; UDP_BUF]);
-            let tx_buf = udp::PacketBuffer::new(tx_meta, vec![0u8; UDP_BUF]);
+            let rx_buf = udp::PacketBuffer::new(rx_meta, vec![0u8; scaled_udp_buf()]);
+            let tx_buf = udp::PacketBuffer::new(tx_meta, vec![0u8; scaled_udp_buf()]);
             let mut socket = udp::Socket::new(rx_buf, tx_buf);
 
             let local_port = alloc_port(&mut s.next_port);

--- a/aether/src/prober.rs
+++ b/aether/src/prober.rs
@@ -214,7 +214,10 @@ impl Strategy {
     /// adjusts them so a 4-core router gets half and a 16-core desktop gets double.
     fn scale_to_host(mut self) -> Self {
         self.concurrency = scale(self.concurrency, REFERENCE_CORES).max(2);
-        self.sample_per_cidr = scale(self.sample_per_cidr, REFERENCE_CORES).max(8);
+        // 0 is a sentinel meaning "full subnet / use fallback default" — don't scale it
+        if self.sample_per_cidr > 0 {
+            self.sample_per_cidr = scale(self.sample_per_cidr, REFERENCE_CORES).max(8);
+        }
         self
     }
 }

--- a/aether/src/prober.rs
+++ b/aether/src/prober.rs
@@ -185,6 +185,40 @@ struct Strategy {
     sample_per_cidr: usize,
 }
 
+/// Number of usable CPU cores, cached for the process lifetime.
+pub fn cpu_cores() -> usize {
+    use std::sync::OnceLock;
+    static CORES: OnceLock<usize> = OnceLock::new();
+    *CORES.get_or_init(|| {
+        let n = std::thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or(1);
+        log::info!("[+] detected {n} CPU core(s); scaling scan parameters accordingly");
+        n
+    })
+}
+
+/// Scale a baseline value (tuned for 8 cores) proportionally to actual core count.
+/// Minimum 1, rounds up so low-core devices still get a usable value.
+pub fn scale(baseline: usize, reference_cores: usize) -> usize {
+    ((baseline as u64 * cpu_cores() as u64 + (reference_cores as u64 - 1))
+        / reference_cores as u64)
+        .max(1) as usize
+}
+
+const REFERENCE_CORES: usize = 8;
+
+impl Strategy {
+    /// Scale concurrency and candidate pool to match the host's CPU capacity.
+    /// The hardcoded values were tuned for ~8-core machines; this proportionally
+    /// adjusts them so a 4-core router gets half and a 16-core desktop gets double.
+    fn scale_to_host(mut self) -> Self {
+        self.concurrency = scale(self.concurrency, REFERENCE_CORES).max(2);
+        self.sample_per_cidr = scale(self.sample_per_cidr, REFERENCE_CORES).max(8);
+        self
+    }
+}
+
 #[derive(Clone)]
 pub struct MasqueProbe {
     pub sni: String,
@@ -207,7 +241,7 @@ pub async fn host_has_ipv6() -> bool {
 }
 
 pub async fn hunt_best_gateway(probe: &MasqueProbe, mode: ScanMode) -> Result<ProbeResult> {
-    let st = mode.strategy();
+    let st = mode.strategy().scale_to_host();
     let timeout = st.per_probe_timeout;
     let mut effective_ip = probe.ip;
     if probe.ip.want_v6() && !host_has_ipv6().await {

--- a/aether/src/quic.rs
+++ b/aether/src/quic.rs
@@ -22,11 +22,27 @@ async fn bind_udp_fast(bind_addr: SocketAddr) -> Result<UdpSocket> {
     let domain = if bind_addr.is_ipv4() { Domain::IPV4 } else { Domain::IPV6 };
     let sock = Socket::new(domain, Type::DGRAM, None).map_err(AetherError::Io)?;
     sock.set_nonblocking(true).map_err(AetherError::Io)?;
-    
-    let buf_size = 7 * 1024 * 1024; // 7MB
+
+    // Scale socket buffers to system memory: 7MB for 4GB+, down to 512KB for tiny routers.
+    // Requesting more than the kernel's rmem_max/wmem_max silently clamps, so aim high.
+    let buf_size = {
+        let pages = unsafe { libc::sysconf(libc::_SC_PHYS_PAGES) };
+        let page_size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
+        if pages > 0 && page_size > 0 {
+            let total_mb = (pages as u64 * page_size as u64) / (1024 * 1024);
+            match total_mb {
+                0..=256 => 512 * 1024,
+                257..=1024 => 2 * 1024 * 1024,
+                1025..=4096 => 4 * 1024 * 1024,
+                _ => 7 * 1024 * 1024,
+            }
+        } else {
+            7 * 1024 * 1024
+        }
+    };
     let _ = sock.set_recv_buffer_size(buf_size);
     let _ = sock.set_send_buffer_size(buf_size);
-    
+
     sock.bind(&bind_addr.into()).map_err(AetherError::Io)?;
     UdpSocket::from_std(sock.into()).map_err(AetherError::Io)
 }

--- a/aether/src/quic.rs
+++ b/aether/src/quic.rs
@@ -26,19 +26,24 @@ async fn bind_udp_fast(bind_addr: SocketAddr) -> Result<UdpSocket> {
     // Scale socket buffers to system memory: 7MB for 4GB+, down to 512KB for tiny routers.
     // Requesting more than the kernel's rmem_max/wmem_max silently clamps, so aim high.
     let buf_size = {
-        let pages = unsafe { libc::sysconf(libc::_SC_PHYS_PAGES) };
-        let page_size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
-        if pages > 0 && page_size > 0 {
-            let total_mb = (pages as u64 * page_size as u64) / (1024 * 1024);
-            match total_mb {
-                0..=256 => 512 * 1024,
-                257..=1024 => 2 * 1024 * 1024,
-                1025..=4096 => 4 * 1024 * 1024,
-                _ => 7 * 1024 * 1024,
+        #[cfg(unix)]
+        {
+            let pages = unsafe { libc::sysconf(libc::_SC_PHYS_PAGES) };
+            let page_size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
+            if pages > 0 && page_size > 0 {
+                let total_mb = (pages as u64 * page_size as u64) / (1024 * 1024);
+                match total_mb {
+                    0..=256 => 512 * 1024,
+                    257..=1024 => 2 * 1024 * 1024,
+                    1025..=4096 => 4 * 1024 * 1024,
+                    _ => 7 * 1024 * 1024,
+                }
+            } else {
+                7 * 1024 * 1024
             }
-        } else {
-            7 * 1024 * 1024
         }
+        #[cfg(not(unix))]
+        { 7 * 1024 * 1024 }
     };
     let _ = sock.set_recv_buffer_size(buf_size);
     let _ = sock.set_send_buffer_size(buf_size);

--- a/aether/src/wg_prober.rs
+++ b/aether/src/wg_prober.rs
@@ -117,6 +117,14 @@ struct WgStrategy {
     sample_per_cidr: usize,
 }
 
+impl WgStrategy {
+    fn scale_to_host(mut self) -> Self {
+        self.concurrency = crate::prober::scale(self.concurrency, 8).max(2);
+        self.sample_per_cidr = crate::prober::scale(self.sample_per_cidr, 8).max(8);
+        self
+    }
+}
+
 #[derive(Clone)]
 pub struct WgProbe {
     pub private_key: Arc<[u8; 32]>,
@@ -129,7 +137,7 @@ pub struct WgProbe {
 }
 
 pub async fn hunt_best_wg_endpoint(probe: &WgProbe, mode: WgScanMode) -> Result<WgProbeResult> {
-    let st = mode.strategy();
+    let st = mode.strategy().scale_to_host();
     let timeout = st.per_probe_timeout;
     let mut effective_ip = probe.ip;
     if probe.ip.want_v6() && !crate::prober::host_has_ipv6().await {

--- a/aether/src/wg_prober.rs
+++ b/aether/src/wg_prober.rs
@@ -120,7 +120,9 @@ struct WgStrategy {
 impl WgStrategy {
     fn scale_to_host(mut self) -> Self {
         self.concurrency = crate::prober::scale(self.concurrency, 8).max(2);
-        self.sample_per_cidr = crate::prober::scale(self.sample_per_cidr, 8).max(8);
+        if self.sample_per_cidr > 0 {
+            self.sample_per_cidr = crate::prober::scale(self.sample_per_cidr, 8).max(8);
+        }
         self
     }
 }


### PR DESCRIPTION
## Problem

Scan parameters and buffer sizes are hardcoded for desktop machines (8+ cores, 4GB+ RAM):

| Parameter | Hardcoded value | Effect on 4-core / 512MB router |
|---|---|---|
| `prober.rs` turbo concurrency | 20 | 20 concurrent TLS handshakes saturate all 4 cores, every probe times out, scanner appears stuck |
| `prober.rs` balanced concurrency | 16 | Same CPU starvation |
| `wg_prober.rs` concurrency | 12 | Same |
| `quic.rs` socket buffer | 7MB | Kernel `rmem_max` is typically 208KB on OpenWrt, `set_recv_buffer_size(7MB)` silently clamps to 208KB |
| `netstack.rs` TCP buffer | 512KB per connection | On a 128MB device, 10 concurrent connections = 10MB just in TCP buffers |

Additionally, `config.rs` uses `expect()` on base64 decode of WG keys, which panics on corrupted config files instead of returning an error. Config files are saved world-readable, exposing WG private keys and access tokens.

## Solution

### Commit 1: perf — scale to host hardware

**`prober.rs`**: Add `cpu_cores()` (cached via `OnceLock`) and `scale(baseline, reference_cores)` that proportionally adjusts values based on detected core count vs a baseline of 8. `Strategy::scale_to_host()` applies this to `concurrency` (min 2) and `sample_per_cidr` (min 8). Called at the start of `hunt_best_gateway()`.

| Host | Turbo concurrency | Balanced concurrency |
|---|---|---|
| 8-core desktop | 20 (unchanged) | 16 (unchanged) |
| 4-core router | 10 | 8 |
| 2-core device | 5 | 4 |

**`wg_prober.rs`**: Same `scale_to_host()` applied to WireGuard scan strategies.

**`quic.rs`**: `bind_udp_fast()` reads system memory via `libc::sysconf(SC_PHYS_PAGES)` and scales socket buffers: 512KB (≤256MB RAM) → 2MB (≤1GB) → 4MB (≤4GB) → 7MB (4GB+).

**`netstack.rs`**: `scaled_tcp_buf()` uses same memory detection: 64KB (≤256MB) → 128KB (≤1GB) → 256KB (≤4GB) → 512KB (4GB+).

**`config.rs`**: Save config files with `0o600` permissions. Replace `expect("invalid base64")` with `TryFrom` that returns `AetherError` on corrupted keys.

### Commit 2: fix — cfg(unix) cross-platform guards

The `libc::sysconf` calls from commit 1 are unix-only. Wrap them in `#[cfg(unix)]` blocks with fallback to original hardcoded values on non-unix platforms.

### Commit 3: fix — preserve sample_per_cidr sentinel value 0

`Thorough` mode uses `sample_per_cidr: 0` as a sentinel meaning "full subnet / use fallback default" (the downstream code checks `if st.sample_per_cidr == 0` and substitutes 96 for MASQUE or 80 for WG). Without this fix, `scale(0, 8).max(8)` turns the sentinel into `8`, breaking the check and reducing IPv6 candidate sampling from 96/80 down to 8. Fixed by skipping scaling when baseline is 0.

### No new problems introduced

- **Desktop unchanged**: `scale(20, 8)` on 8-core machine returns 20 — identical behavior
- **Graceful fallback**: if `available_parallelism()` fails, defaults to 1 core (most conservative)
- **Buffer clamp is safe**: requesting less than kernel max just works; requesting more already silently clamped
- **Thorough mode preserved**: sentinel `0` is never scaled, downstream fallback logic works correctly
- **No new dependencies**: `std::thread::available_parallelism()` (stable since Rust 1.59), `libc::sysconf` (already a dependency via tokio/boring)

## Test plan

- [ ] Build and run on 8-core desktop — scan timing and behavior identical to before
- [ ] Build and run on 4-core ARM router — concurrency halved, scans complete without CPU starvation
- [ ] Run `--scan thorough -4` — verify scan uses full subnet (not just 8 candidates per CIDR)
- [ ] `cargo build --target x86_64-pc-windows-msvc` — compiles without libc errors
- [ ] Verify saved config files have 0600 permissions: `stat -c %a aether.toml` → `600`
- [ ] Corrupt a config file's base64 key → error message instead of panic

🤖 Generated with [Claude Code](https://claude.com/claude-code)