### PR TITLE
feat: WARP+ license key support via --key flag

### DIFF
--- a/Docs/GUIDE.en.md
+++ b/Docs/GUIDE.en.md
@@ -214,6 +214,10 @@ Every prompt has a variable equivalent. If you set a variable beforehand, Aether
 
 - `AETHER_QUICK_RECONNECT` (`--quick-reconnect` / `--no-quick-reconnect`) — set to `1` to always reuse the last known-good gateway without asking, or `0` to always scan fresh without asking. Unset means Aether asks you at startup if a cached gateway exists.
 
+### WARP+ / 1.1.1.1 Premium license
+
+- `AETHER_KEY` (`--key`, `-K`) — your WARP+ or 1.1.1.1 premium license key. Applied after device registration. Works with all protocols. **Note:** WARP-in-WARP (`gool`) registers two devices and uses 2 of your 5 license slots.
+
 ### Forcing the endpoint and the config path
 
 - `AETHER_PEER` or `AETHER_WG_PEER` (`--peer`, `--wg-peer`) — if you want to give a fixed address yourself and bypass the scan.

--- a/README.md
+++ b/README.md
@@ -114,6 +114,24 @@ Or skip the prompts with flags:
 ./target/release/aether --masque -4 --scan turbo --noize firewall
 ```
 
+### WARP+ / 1.1.1.1 Premium
+
+If you have a WARP+ or 1.1.1.1 premium subscription, apply your license key with `--key` (or `-K`):
+
+```bash
+aether --masque --key YOUR-LICENSE-KEY
+```
+
+Or via environment variable:
+
+```bash
+AETHER_KEY=YOUR-LICENSE-KEY aether --masque
+```
+
+The license is applied after device registration and works with all protocols (MASQUE, WireGuard, WARP-in-WARP). You can find your license key in the 1.1.1.1 app under **Settings → Account → Key**.
+
+> **Note:** WARP-in-WARP (`--gool`) registers two separate devices (outer + inner tunnel), so it uses **2 of your 5 device slots** on the license.
+
 On Windows, double-click `run-aether.bat` (included in the release zip) instead — it opens a terminal, runs `aether.exe`, and keeps the window open afterwards so you can read any errors.
 
 Every prompt has a flag and an environment variable equivalent. Run `./target/release/aether --help` for the full list, or see the guides linked below.

--- a/aether/src/account.rs
+++ b/aether/src/account.rs
@@ -257,6 +257,52 @@ pub async fn enroll_key(
     parse_account(resp).await
 }
 
+pub async fn update_license(device_id: &str, token: &str, license_key: &str) -> Result<()> {
+    let url = format!(
+        "{}/{}/reg/{}/account",
+        consts::API_URL,
+        consts::API_VERSION,
+        device_id
+    );
+
+    let body = serde_json::json!({ "license": license_key });
+
+    let resp = http_client()?
+        .put(url)
+        .headers(base_headers())
+        .bearer_auth(token)
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| AetherError::Api(e.to_string()))?;
+
+    let status = resp.status();
+    let text = resp
+        .text()
+        .await
+        .map_err(|e| AetherError::Api(e.to_string()))?;
+
+    if !status.is_success() {
+        return Err(AetherError::Api(format!(
+            "license update failed (status {status}): {text}"
+        )));
+    }
+
+    // Check if WARP+ activated
+    if let Ok(v) = serde_json::from_str::<serde_json::Value>(&text) {
+        if v.get("warp_plus").and_then(|w| w.as_bool()) == Some(true) {
+            log::info!("[+] WARP+ license activated successfully");
+        } else {
+            log::warn!("[-] license applied but warp_plus not confirmed in response");
+        }
+        if let Some(quota) = v.get("premium_data").and_then(|p| p.as_u64()) {
+            log::info!("[+] premium data quota: {} bytes", quota);
+        }
+    }
+
+    Ok(())
+}
+
 async fn parse_account(resp: reqwest::Response) -> Result<AccountData> {
     let status = resp.status();
     let text = resp.text().await.map_err(|e| AetherError::Api(e.to_string()))?;

--- a/aether/src/cli.rs
+++ b/aether/src/cli.rs
@@ -5,6 +5,7 @@ Usage: aether [OPTIONS]
 
 Connection:
   --bind <addr>            local SOCKS5 listen address (default 127.0.0.1:1819)
+  --key <license>, -K      apply a WARP+ / 1.1.1.1 premium license key
   --quick-reconnect        auto-accept reconnecting with the last known working gateway
   --no-quick-reconnect     always scan fresh, ignore any saved last-connection gateway
   -4                       scan/connect over IPv4 only (default)
@@ -86,6 +87,7 @@ pub fn parse_and_apply() -> crate::error::Result<()> {
             }
 
             "--bind" => set("AETHER_SOCKS", next_value!()),
+            "--key" | "-K" => set("AETHER_KEY", next_value!()),
             "--quick-reconnect" => set("AETHER_QUICK_RECONNECT", "1"),
             "--no-quick-reconnect" => set("AETHER_QUICK_RECONNECT", "0"),
 

--- a/aether/src/main.rs
+++ b/aether/src/main.rs
@@ -165,9 +165,20 @@ fn derive_sibling_path(base: &str, suffix: &str) -> String {
     }
 }
 
+async fn apply_license_if_set(identity: &account::Identity) -> Result<()> {
+    if let Ok(key) = std::env::var("AETHER_KEY") {
+        if !key.is_empty() {
+            log::info!("[*] applying WARP+ license key to device {}", identity.device_id);
+            account::update_license(&identity.device_id, &identity.access_token, &key).await?;
+        }
+    }
+    Ok(())
+}
+
 async fn load_or_provision_warp(config_path: &str) -> Result<account::Identity> {
     if let Some(identity) = config::load(config_path)? {
         log::info!("[+] loaded existing warp identity from {config_path}");
+        apply_license_if_set(&identity).await?;
         return Ok(identity);
     }
 
@@ -175,12 +186,14 @@ async fn load_or_provision_warp(config_path: &str) -> Result<account::Identity> 
     let identity = account::provision_wg(consts::DEFAULT_MODEL, consts::DEFAULT_LOCALE, None).await?;
     config::save(config_path, &identity)?;
     log::info!("[+] provisioned and saved new warp identity to {config_path}");
+    apply_license_if_set(&identity).await?;
     Ok(identity)
 }
 
 async fn load_or_provision_masque(config_path: &str) -> Result<account::Identity> {
     if let Some(identity) = config::load(config_path)? {
         log::info!("[+] loaded existing masque identity from {config_path}");
+        apply_license_if_set(&identity).await?;
         if identity.has_masque_credentials() {
             return Ok(identity);
         }
@@ -193,6 +206,7 @@ async fn load_or_provision_masque(config_path: &str) -> Result<account::Identity
 
     log::info!("[+] no masque identity found; provisioning dedicated masque account");
     let identity = account::provision_wg(consts::DEFAULT_MODEL, consts::DEFAULT_LOCALE, None).await?;
+    apply_license_if_set(&identity).await?;
     let (cert_pem, key_pem) = account::ensure_masque_enrolled(&identity).await?;
     let identity = account::Identity { cert_pem, key_pem, ..identity };
     config::save(config_path, &identity)?;

--- a/aether/src/main.rs
+++ b/aether/src/main.rs
@@ -165,20 +165,20 @@ fn derive_sibling_path(base: &str, suffix: &str) -> String {
     }
 }
 
-async fn apply_license_if_set(identity: &account::Identity) -> Result<()> {
+async fn apply_license_if_set(identity: &account::Identity) {
     if let Ok(key) = std::env::var("AETHER_KEY") {
         if !key.is_empty() {
             log::info!("[*] applying WARP+ license key to device {}", identity.device_id);
-            account::update_license(&identity.device_id, &identity.access_token, &key).await?;
+            if let Err(e) = account::update_license(&identity.device_id, &identity.access_token, &key).await {
+                log::warn!("[-] license key application failed (continuing without WARP+): {e}");
+            }
         }
     }
-    Ok(())
 }
 
 async fn load_or_provision_warp(config_path: &str) -> Result<account::Identity> {
     if let Some(identity) = config::load(config_path)? {
         log::info!("[+] loaded existing warp identity from {config_path}");
-        apply_license_if_set(&identity).await?;
         return Ok(identity);
     }
 
@@ -186,14 +186,13 @@ async fn load_or_provision_warp(config_path: &str) -> Result<account::Identity> 
     let identity = account::provision_wg(consts::DEFAULT_MODEL, consts::DEFAULT_LOCALE, None).await?;
     config::save(config_path, &identity)?;
     log::info!("[+] provisioned and saved new warp identity to {config_path}");
-    apply_license_if_set(&identity).await?;
+    apply_license_if_set(&identity).await;
     Ok(identity)
 }
 
 async fn load_or_provision_masque(config_path: &str) -> Result<account::Identity> {
     if let Some(identity) = config::load(config_path)? {
         log::info!("[+] loaded existing masque identity from {config_path}");
-        apply_license_if_set(&identity).await?;
         if identity.has_masque_credentials() {
             return Ok(identity);
         }
@@ -206,7 +205,7 @@ async fn load_or_provision_masque(config_path: &str) -> Result<account::Identity
 
     log::info!("[+] no masque identity found; provisioning dedicated masque account");
     let identity = account::provision_wg(consts::DEFAULT_MODEL, consts::DEFAULT_LOCALE, None).await?;
-    apply_license_if_set(&identity).await?;
+    apply_license_if_set(&identity).await;
     let (cert_pem, key_pem) = account::ensure_masque_enrolled(&identity).await?;
     let identity = account::Identity { cert_pem, key_pem, ..identity };
     config::save(config_path, &identity)?;


### PR DESCRIPTION
## Problem

Users with WARP+ / 1.1.1.1 premium subscriptions have no way to apply their license key through Aether. The Cloudflare WARP API supports license activation via `PUT /reg/{device_id}/account` with `{"license": "..."}`, but Aether has no CLI interface for it.

## Solution

Add `--key <license>` / `-K` CLI flag (and `AETHER_KEY` env var) that calls the Cloudflare WARP license endpoint after device registration.

### Implementation

1. **`cli.rs`**: `--key` / `-K` sets `AETHER_KEY` env var (same pattern as all other CLI flags)
2. **`account.rs`**: new `update_license()` sends `PUT /v0a2517/reg/{device_id}/account` with `{"license": key}`, authenticated with the device's bearer token. Logs whether `warp_plus: true` was confirmed in the response and the premium data quota.
3. **`main.rs`**: new `apply_license_if_set()` checks `AETHER_KEY` env var and calls `update_license()`. Called **only on new device provisioning** (not on every startup load) to avoid unnecessary API traffic and potential rate limiting.

### Error handling

`apply_license_if_set()` returns `()`, not `Result`. If the license API call fails (bad key, network error, rate limit), it logs a warning and continues — the tunnel starts on the free tier instead of aborting entirely. This is deliberate: a bad license key should not prevent the tunnel from working.

### No new problems introduced

- **No-op without `--key`**: checks `AETHER_KEY` env var, returns immediately if unset/empty
- **Non-fatal errors**: API failures log a warning, tunnel proceeds normally on free tier
- **No API spam**: only called on first provision (new device registration), not on every startup when loading existing config
- **Idempotent**: calling `update_license()` with an already-applied key is a no-op on Cloudflare's side
- **No new dependencies**: uses existing `reqwest`, `serde_json`, and the `http_client()`/`base_headers()` helpers

## Test plan

- [ ] `aether --masque --key <valid-key>` on fresh install — logs "WARP+ license activated successfully"
- [ ] `aether --masque --key invalid-key` on fresh install — logs warning, tunnel starts without WARP+
- [ ] `aether --masque --key <key>` on existing config — no license API call (already provisioned)
- [ ] `aether --masque` (no key) — no change in behavior
- [ ] Delete config, re-run with `--key` — license applied on new provisioning

🤖 Generated with [Claude Code](https://claude.com/claude-code)