### PR TITLE
fix: pre-allocate WG encapsulate/timer buffers outside hot loops

### DIFF
--- a/aether/src/wireguard.rs
+++ b/aether/src/wireguard.rs
@@ -161,9 +161,10 @@ impl WgTunnel {
         });
 
         let send_task = tokio::spawn(async move {
+            let mut out_buf = vec![0u8; MAX_PACKET]; // ponytail: reuse single buffer, not alloc-per-packet
+
             while let Some(ip_packet) = outbound_rx.recv().await {
                 let mut tunn = tunn_w.lock().await;
-                let mut out_buf = vec![0u8; MAX_PACKET];
 
                 match tunn.encapsulate(&ip_packet, &mut out_buf) {
                     TunnResult::Done => {}
@@ -201,10 +202,10 @@ impl WgTunnel {
 
         let timer_task = tokio::spawn(async move {
             let mut interval = tokio::time::interval(TIMER_TICK);
+            let mut tmp = vec![0u8; MAX_PACKET]; // ponytail: reuse single buffer, not alloc-per-tick
             loop {
                 interval.tick().await;
                 let mut tunn = tunn_t.lock().await;
-                let mut tmp = vec![0u8; MAX_PACKET];
                 if let TunnResult::WriteToNetwork(pkt) = tunn.update_timers(&mut tmp) {
                     let mut pkt_vec = pkt.to_vec();
                     inject_client_id(&mut pkt_vec, &client_id);


### PR DESCRIPTION
## Problem

In `wireguard.rs`, two `vec![0u8; MAX_PACKET]` (65KB each) allocations sit inside hot loops:

1. **`out_buf`** inside `while let Some(ip_packet) = outbound_rx.recv().await` — allocates 65KB on **every outbound packet**
2. **`tmp`** inside `loop { interval.tick().await; ... }` — allocates 65KB on **every 250ms timer tick**

On a router pushing traffic, this means thousands of 65KB allocations per second that are immediately dropped. On memory-constrained devices (128-512MB), this creates allocation churn that fragments the heap and drives RSS growth.

## Solution

Move both allocations before their respective loops — allocated once, reused on every iteration.

```rust
// BEFORE (per-packet):
while let Some(ip_packet) = outbound_rx.recv().await {
    let mut out_buf = vec![0u8; MAX_PACKET];  // 65KB every packet
    ...
}

// AFTER (once):
let mut out_buf = vec![0u8; MAX_PACKET];  // 65KB once
while let Some(ip_packet) = outbound_rx.recv().await {
    ...
}
```

Same pattern for the timer task's `tmp` buffer.

### Why it's safe

- `tunn.encapsulate()` and `tunn.update_timers()` both write into the buffer from index 0 and return `TunnResult::WriteToNetwork(pkt)` where `pkt` is a slice `&buf[..written_len]`
- Neither function reads pre-existing buffer contents — stale data is overwritten before being read
- `pkt.to_vec()` only copies the newly written bytes, ignoring any trailing unwritten portion

Fixes #24

## Test plan

- [ ] Run WireGuard tunnel under sustained traffic — RSS stays flat instead of growing
- [ ] Verify tunnel still passes data correctly (encapsulate/decapsulate unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)