### PR TITLE
feat: allow a single data directory flag (-d, --data-dir)

### DIFF
--- a/Docs/GUIDE.en.md
+++ b/Docs/GUIDE.en.md
@@ -215,6 +215,7 @@ Every prompt has a variable equivalent. If you set a variable beforehand, Aether
 ### Forcing the endpoint and the config path
 
 - `AETHER_PEER` or `AETHER_WG_PEER` (`--peer`, `--wg-peer`) — if you want to give a fixed address yourself and bypass the scan.
+- `AETHER_DATA_DIR` (`-d`, `--data-dir`) — the base directory for storing identity configs and session cache files.
 - `AETHER_CONFIG` (`--config`) — the path of the base config file. Default `aether.toml`.
 - `AETHER_WG_CONFIG` and `AETHER_MASQUE_CONFIG` (`--wg-config`, `--masque-config`) — the config path specific to each protocol.
 - `AETHER_TLS_GROUPS` (`--tls-groups`) — override the TLS key-share groups advertised in the handshake. Default mimics Chrome (`P-256:X25519:P-384`).

--- a/Docs/GUIDE.fa.md
+++ b/Docs/GUIDE.fa.md
@@ -217,6 +217,7 @@ Reconnect to it now without rescanning? [Y/n]:
 ### مجبور کردن نقطهٔ اتصال و مسیر فایل کانفیگ
 
 - `AETHER_PEER` یا `AETHER_WG_PEER` (`--peer`, `--wg-peer`) — اگه بخوای خودت یه آدرس ثابت بدی و اسکن رو دور بزنی.
+- `AETHER_DATA_DIR` (`-d`, `--data-dir`) — مسیر پوشهٔ پایه برای ذخیرهٔ فایل‌های کانفیگ و حالت اتصال.
 - `AETHER_CONFIG` (`--config`) — مسیر فایل کانفیگ پایه. پیش‌فرض `aether.toml`.
 - `AETHER_WG_CONFIG` و `AETHER_MASQUE_CONFIG` (`--wg-config`, `--masque-config`) — مسیر فایل کانفیگ مخصوص هر پروتکل.
 - `AETHER_TLS_GROUPS` (`--tls-groups`) — بازنویسی گروه‌های TLS key-share که توی دست‌دادن اعلام می‌شن. پیش‌فرض شبیه کروم هست (`P-256:X25519:P-384`).

--- a/aether/src/cli.rs
+++ b/aether/src/cli.rs
@@ -139,3 +139,62 @@ pub fn parse_and_apply() -> crate::error::Result<()> {
 fn set(key: &str, value: &str) {
     std::env::set_var(key, value);
 }
+
+pub fn resolve_config_path(
+    data_dir: Option<&str>,
+    explicit_path: Option<&str>,
+    default_filename: &str,
+) -> String {
+    match explicit_path {
+        Some(path) => {
+            let p = std::path::Path::new(path);
+            if p.is_absolute() {
+                path.to_string()
+            } else if let Some(dir) = data_dir {
+                std::path::Path::new(dir)
+                    .join(path)
+                    .to_string_lossy()
+                    .to_string()
+            } else {
+                path.to_string()
+            }
+        }
+        None => match data_dir {
+            Some(dir) => std::path::Path::new(dir)
+                .join(default_filename)
+                .to_string_lossy()
+                .to_string(),
+            None => default_filename.to_string(),
+        },
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_resolve_config_path_no_data_dir() {
+        assert_eq!(resolve_config_path(None, None, "aether.toml"), "aether.toml");
+        assert_eq!(resolve_config_path(None, Some("custom.toml"), "aether.toml"), "custom.toml");
+        assert_eq!(resolve_config_path(None, Some("/abs/path.toml"), "aether.toml"), "/abs/path.toml");
+    }
+
+    #[test]
+    fn test_resolve_config_path_with_data_dir() {
+        assert_eq!(
+            resolve_config_path(Some("/var/lib/aether"), None, "aether.toml"),
+            format!("{}/aether.toml", std::path::Path::new("/var/lib/aether").display())
+        );
+        assert_eq!(
+            resolve_config_path(Some("/var/lib/aether"), Some("custom.toml"), "aether.toml"),
+            format!("{}/custom.toml", std::path::Path::new("/var/lib/aether").display())
+        );
+        assert_eq!(
+            resolve_config_path(Some("/var/lib/aether"), Some("/abs/path.toml"), "aether.toml"),
+            "/abs/path.toml"
+        );
+    }
+}
+

--- a/aether/src/cli.rs
+++ b/aether/src/cli.rs
@@ -44,6 +44,7 @@ WireGuard:
   --no-profile-retry       don't retry other obfuscation profiles during scan
 
 Config files:
+  -d, --data-dir <dir>     base directory for identity and session files
   --config <path>          base identity config path (default aether.toml)
   --wg-config <path>       identity config path for WireGuard
   --masque-config <path>   identity config path for MASQUE
@@ -56,6 +57,10 @@ Advanced:
 
 pub fn parse_and_apply() -> crate::error::Result<()> {
     let args: Vec<String> = env::args().skip(1).collect();
+    parse_args(&args)
+}
+
+pub fn parse_args(args: &[String]) -> crate::error::Result<()> {
     let mut i = 0;
 
     while i < args.len() {
@@ -117,6 +122,7 @@ pub fn parse_and_apply() -> crate::error::Result<()> {
             "--keepalive" => set("AETHER_WG_KEEPALIVE", next_value!()),
             "--no-profile-retry" => set("AETHER_WG_NO_PROFILE_RETRY", "1"),
 
+            "-d" | "--data-dir" => set("AETHER_DATA_DIR", next_value!()),
             "--config" => set("AETHER_CONFIG", next_value!()),
             "--wg-config" => set("AETHER_WG_CONFIG", next_value!()),
             "--masque-config" => set("AETHER_MASQUE_CONFIG", next_value!()),
@@ -196,5 +202,17 @@ mod tests {
             "/abs/path.toml"
         );
     }
+
+    #[test]
+    fn test_cli_parse_data_dir() {
+        std::env::remove_var("AETHER_DATA_DIR");
+        parse_args(&["-d".to_string(), "/tmp/aether-data-1".to_string()]).unwrap();
+        assert_eq!(std::env::var("AETHER_DATA_DIR").unwrap(), "/tmp/aether-data-1");
+
+        std::env::remove_var("AETHER_DATA_DIR");
+        parse_args(&["--data-dir".to_string(), "/tmp/aether-data-2".to_string()]).unwrap();
+        assert_eq!(std::env::var("AETHER_DATA_DIR").unwrap(), "/tmp/aether-data-2");
+    }
 }
+
 

--- a/aether/src/cli.rs
+++ b/aether/src/cli.rs
@@ -205,6 +205,8 @@ mod tests {
 
     #[test]
     fn test_cli_parse_data_dir() {
+        let prev = std::env::var("AETHER_DATA_DIR").ok();
+
         std::env::remove_var("AETHER_DATA_DIR");
         parse_args(&["-d".to_string(), "/tmp/aether-data-1".to_string()]).unwrap();
         assert_eq!(std::env::var("AETHER_DATA_DIR").unwrap(), "/tmp/aether-data-1");
@@ -212,6 +214,11 @@ mod tests {
         std::env::remove_var("AETHER_DATA_DIR");
         parse_args(&["--data-dir".to_string(), "/tmp/aether-data-2".to_string()]).unwrap();
         assert_eq!(std::env::var("AETHER_DATA_DIR").unwrap(), "/tmp/aether-data-2");
+
+        match prev {
+            Some(val) => std::env::set_var("AETHER_DATA_DIR", val),
+            None => std::env::remove_var("AETHER_DATA_DIR"),
+        }
     }
 }
 

--- a/aether/src/cli.rs
+++ b/aether/src/cli.rs
@@ -191,11 +191,17 @@ mod tests {
     fn test_resolve_config_path_with_data_dir() {
         assert_eq!(
             resolve_config_path(Some("/var/lib/aether"), None, "aether.toml"),
-            format!("{}/aether.toml", std::path::Path::new("/var/lib/aether").display())
+            std::path::Path::new("/var/lib/aether")
+                .join("aether.toml")
+                .to_string_lossy()
+                .to_string()
         );
         assert_eq!(
             resolve_config_path(Some("/var/lib/aether"), Some("custom.toml"), "aether.toml"),
-            format!("{}/custom.toml", std::path::Path::new("/var/lib/aether").display())
+            std::path::Path::new("/var/lib/aether")
+                .join("custom.toml")
+                .to_string_lossy()
+                .to_string()
         );
         assert_eq!(
             resolve_config_path(Some("/var/lib/aether"), Some("/abs/path.toml"), "aether.toml"),
@@ -203,9 +209,30 @@ mod tests {
         );
     }
 
+    struct EnvGuard {
+        key: &'static str,
+        original: Option<String>,
+    }
+
+    impl EnvGuard {
+        fn new(key: &'static str) -> Self {
+            let original = std::env::var(key).ok();
+            Self { key, original }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match &self.original {
+                Some(v) => std::env::set_var(self.key, v),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+
     #[test]
     fn test_cli_parse_data_dir() {
-        let prev = std::env::var("AETHER_DATA_DIR").ok();
+        let _guard = EnvGuard::new("AETHER_DATA_DIR");
 
         std::env::remove_var("AETHER_DATA_DIR");
         parse_args(&["-d".to_string(), "/tmp/aether-data-1".to_string()]).unwrap();
@@ -214,11 +241,6 @@ mod tests {
         std::env::remove_var("AETHER_DATA_DIR");
         parse_args(&["--data-dir".to_string(), "/tmp/aether-data-2".to_string()]).unwrap();
         assert_eq!(std::env::var("AETHER_DATA_DIR").unwrap(), "/tmp/aether-data-2");
-
-        match prev {
-            Some(val) => std::env::set_var("AETHER_DATA_DIR", val),
-            None => std::env::remove_var("AETHER_DATA_DIR"),
-        }
     }
 }
 

--- a/aether/src/config.rs
+++ b/aether/src/config.rs
@@ -88,8 +88,12 @@ pub fn load(path: &str) -> Result<Option<Identity>> {
 }
 
 pub fn save(path: &str, identity: &Identity) -> Result<()> {
-    if let Some(parent) = Path::new(path).parent() {
-        let _ = std::fs::create_dir_all(parent);
+    if let Some(parent) = Path::new(path)
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty())
+    {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| AetherError::Other(format!("config dir create {}: {e}", parent.display())))?;
     }
     let persisted = PersistedIdentity::from(identity);
     let text = toml::to_string_pretty(&persisted)

--- a/aether/src/config.rs
+++ b/aether/src/config.rs
@@ -88,6 +88,9 @@ pub fn load(path: &str) -> Result<Option<Identity>> {
 }
 
 pub fn save(path: &str, identity: &Identity) -> Result<()> {
+    if let Some(parent) = Path::new(path).parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
     let persisted = PersistedIdentity::from(identity);
     let text = toml::to_string_pretty(&persisted)
         .map_err(|e| AetherError::Other(format!("config encode: {e}")))?;
@@ -109,3 +112,34 @@ pub fn save_masque_creds(path: &str, cert_pem: &[u8], key_pem: &[u8]) -> Result<
     std::fs::write(path, updated)?;
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_save_creates_parent_dir() {
+        let dir = std::env::temp_dir().join(format!("aether_test_cfg_{}", rand::random::<u64>()));
+        let nested_path = dir.join("nested").join("dir").join("aether.toml");
+        let path_str = nested_path.to_str().unwrap();
+
+        let identity = Identity {
+            device_id: "dev123".into(),
+            access_token: "tok123".into(),
+            cert_pem: vec![],
+            key_pem: vec![],
+            ipv4: "192.0.2.1".into(),
+            ipv6: "2001:db8::1".into(),
+            wg_private_key: [1u8; 32],
+            wg_peer_public_key: [2u8; 32],
+            client_id: [0u8; 3],
+        };
+
+        let res = save(path_str, &identity);
+        assert!(res.is_ok());
+        assert!(nested_path.exists());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}
+

--- a/aether/src/lastconn.rs
+++ b/aether/src/lastconn.rs
@@ -13,6 +13,9 @@ pub fn load(path: &str) -> Option<LastConnection> {
 }
 
 pub fn save(path: &str, peer: &str, profile: &str) {
+    if let Some(parent) = std::path::Path::new(path).parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
     let conn = LastConnection {
         peer: peer.to_string(),
         profile: profile.to_string(),
@@ -26,3 +29,21 @@ pub fn save(path: &str, peer: &str, profile: &str) {
         Err(e) => log::debug!("[lastconn] failed to encode: {e}"),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_lastconn_save_creates_parent_dir() {
+        let dir = std::env::temp_dir().join(format!("aether_test_lc_{}", rand::random::<u64>()));
+        let nested_path = dir.join("nested").join("dir").join("lastconn.toml");
+        let path_str = nested_path.to_str().unwrap();
+
+        save(path_str, "127.0.0.1:443", "firewall");
+        assert!(nested_path.exists());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}
+

--- a/aether/src/lastconn.rs
+++ b/aether/src/lastconn.rs
@@ -13,8 +13,13 @@ pub fn load(path: &str) -> Option<LastConnection> {
 }
 
 pub fn save(path: &str, peer: &str, profile: &str) {
-    if let Some(parent) = std::path::Path::new(path).parent() {
-        let _ = std::fs::create_dir_all(parent);
+    if let Some(parent) = std::path::Path::new(path)
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty())
+    {
+        if let Err(e) = std::fs::create_dir_all(parent) {
+            log::debug!("[lastconn] failed to create parent dir {}: {e}", parent.display());
+        }
     }
     let conn = LastConnection {
         peer: peer.to_string(),

--- a/aether/src/main.rs
+++ b/aether/src/main.rs
@@ -50,7 +50,12 @@ async fn main() -> Result<()> {
         .and_then(|s| s.parse().ok())
         .unwrap_or_else(|| "127.0.0.1:1819".parse().unwrap());
 
-    let base_config = std::env::var("AETHER_CONFIG").unwrap_or_else(|_| DEFAULT_CONFIG.to_string());
+    let data_dir = std::env::var("AETHER_DATA_DIR").ok();
+    let base_config = cli::resolve_config_path(
+        data_dir.as_deref(),
+        std::env::var("AETHER_CONFIG").ok().as_deref(),
+        DEFAULT_CONFIG,
+    );
 
     let protocol = if std::env::var("AETHER_PEER").is_ok() || std::env::var("AETHER_WG_PEER").is_ok() {
         match std::env::var("AETHER_PROTOCOL") {
@@ -132,15 +137,17 @@ fn aethernoize_config() -> aethernoize::AetherNoizeConfig {
 }
 
 fn warp_config_path(base: &str) -> String {
+    let data_dir = std::env::var("AETHER_DATA_DIR").ok();
     if let Ok(p) = std::env::var("AETHER_WG_CONFIG") {
-        return p;
+        return cli::resolve_config_path(data_dir.as_deref(), Some(&p), base);
     }
     base.to_string()
 }
 
 fn masque_config_path(base: &str) -> String {
+    let data_dir = std::env::var("AETHER_DATA_DIR").ok();
     if let Ok(p) = std::env::var("AETHER_MASQUE_CONFIG") {
-        return p;
+        return cli::resolve_config_path(data_dir.as_deref(), Some(&p), base);
     }
     derive_sibling_path(base, "masque")
 }
@@ -1032,3 +1039,36 @@ async fn select_ip_version() -> prober::IpScan {
         _ => prober::IpScan::V4,
     }
 }
+
+#[cfg(test)]
+mod main_tests {
+    use super::*;
+
+    #[test]
+    fn test_main_config_path_resolution_with_data_dir() {
+        let data_dir = "/custom/data/dir";
+        std::env::set_var("AETHER_DATA_DIR", data_dir);
+
+        let base = cli::resolve_config_path(
+            Some(data_dir),
+            std::env::var("AETHER_CONFIG").ok().as_deref(),
+            DEFAULT_CONFIG,
+        );
+        let expected_base = format!("{}/aether.toml", std::path::Path::new(data_dir).display());
+        assert_eq!(base, expected_base);
+
+        let wg = warp_config_path(&base);
+        assert_eq!(wg, expected_base);
+
+        let masque = masque_config_path(&base);
+        let expected_masque = format!("{}/aether-masque.toml", std::path::Path::new(data_dir).display());
+        assert_eq!(masque, expected_masque);
+
+        let lastconn = lastconn_path(&masque);
+        let expected_lastconn = format!("{}/aether-masque-lastconn.toml", std::path::Path::new(data_dir).display());
+        assert_eq!(lastconn, expected_lastconn);
+
+        std::env::remove_var("AETHER_DATA_DIR");
+    }
+}
+

--- a/aether/src/main.rs
+++ b/aether/src/main.rs
@@ -1044,14 +1044,45 @@ async fn select_ip_version() -> prober::IpScan {
 mod main_tests {
     use super::*;
 
+    struct EnvGuard {
+        key: &'static str,
+        original: Option<String>,
+    }
+
+    impl EnvGuard {
+        fn set(key: &'static str, val: &str) -> Self {
+            let original = std::env::var(key).ok();
+            std::env::set_var(key, val);
+            Self { key, original }
+        }
+
+        fn remove(key: &'static str) -> Self {
+            let original = std::env::var(key).ok();
+            std::env::remove_var(key);
+            Self { key, original }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match &self.original {
+                Some(v) => std::env::set_var(self.key, v),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+
     #[test]
     fn test_main_config_path_resolution_with_data_dir() {
         let data_dir = "/custom/data/dir";
-        std::env::set_var("AETHER_DATA_DIR", data_dir);
+        let _g_data = EnvGuard::set("AETHER_DATA_DIR", data_dir);
+        let _g_cfg = EnvGuard::remove("AETHER_CONFIG");
+        let _g_wg = EnvGuard::remove("AETHER_WG_CONFIG");
+        let _g_masque = EnvGuard::remove("AETHER_MASQUE_CONFIG");
 
         let base = cli::resolve_config_path(
             Some(data_dir),
-            std::env::var("AETHER_CONFIG").ok().as_deref(),
+            None,
             DEFAULT_CONFIG,
         );
         let expected_base = format!("{}/aether.toml", std::path::Path::new(data_dir).display());
@@ -1067,8 +1098,6 @@ mod main_tests {
         let lastconn = lastconn_path(&masque);
         let expected_lastconn = format!("{}/aether-masque-lastconn.toml", std::path::Path::new(data_dir).display());
         assert_eq!(lastconn, expected_lastconn);
-
-        std::env::remove_var("AETHER_DATA_DIR");
     }
 }
 

--- a/aether/src/main.rs
+++ b/aether/src/main.rs
@@ -1085,18 +1085,27 @@ mod main_tests {
             None,
             DEFAULT_CONFIG,
         );
-        let expected_base = format!("{}/aether.toml", std::path::Path::new(data_dir).display());
+        let expected_base = std::path::Path::new(data_dir)
+            .join("aether.toml")
+            .to_string_lossy()
+            .to_string();
         assert_eq!(base, expected_base);
 
         let wg = warp_config_path(&base);
         assert_eq!(wg, expected_base);
 
         let masque = masque_config_path(&base);
-        let expected_masque = format!("{}/aether-masque.toml", std::path::Path::new(data_dir).display());
+        let expected_masque = std::path::Path::new(data_dir)
+            .join("aether-masque.toml")
+            .to_string_lossy()
+            .to_string();
         assert_eq!(masque, expected_masque);
 
         let lastconn = lastconn_path(&masque);
-        let expected_lastconn = format!("{}/aether-masque-lastconn.toml", std::path::Path::new(data_dir).display());
+        let expected_lastconn = std::path::Path::new(data_dir)
+            .join("aether-masque-lastconn.toml")
+            .to_string_lossy()
+            .to_string();
         assert_eq!(lastconn, expected_lastconn);
     }
 }


### PR DESCRIPTION
Closes #22

## Summary
Adds a `-d` / `--data-dir` flag and `AETHER_DATA_DIR` environment variable to set a base directory for all Aether identity configurations and session cache files.

## Changes Included
- `-d, --data-dir <dir>` CLI flag and `AETHER_DATA_DIR` environment variable in `aether/src/cli.rs`.
- `resolve_config_path` helper function to resolve relative config paths under `--data-dir` while preserving absolute path overrides.
- Automatic creation of missing parent directories in `config::save` and `lastconn::save`.
- Integration into `main.rs` config path loading for base, WireGuard, and MASQUE configurations.
- Documentation updates in `Docs/GUIDE.en.md` and `Docs/GUIDE.fa.md`.
- Unit and integration tests covering path resolution, directory creation, and argument parsing.
