### PR TITLE
Improve connection resilience

### DIFF
--- a/Docs/GUIDE.en.md
+++ b/Docs/GUIDE.en.md
@@ -201,6 +201,7 @@ Every prompt has a variable equivalent. If you set a variable beforehand, Aether
 - `AETHER_MASQUE_H2_FRAGMENT_DELAY` (`--fragment-delay`) — delay between fragments in ms, `n` or `a-b`. Default `2-10`.
 - `AETHER_MASQUE_NO_DATA_CHECK` (`--no-data-check`) — if set, a `:status 200` alone is enough; the end-to-end data-plane probe is skipped.
 - `AETHER_MASQUE_VALIDATE_SECS` (`--validate-secs`) — seconds to wait for the data-plane probe to succeed before giving up on a gateway. Default `10`.
+- `AETHER_MASQUE_STARTUP_SECS` (`--startup-secs`) — total deadline for TCP/QUIC, TLS, CONNECT-IP, and initial data-plane validation. Default `30`.
 - `AETHER_MASQUE_RECONNECT_SECS` (`--reconnect-secs`) — delay before automatically reconnecting after the MASQUE tunnel drops or fails validation. Default `2`.
 - `AETHER_WG_RECONNECT_SECS` — delay before automatically reconnecting after the WireGuard tunnel drops. Default `2`.
 
@@ -219,6 +220,7 @@ Every prompt has a variable equivalent. If you set a variable beforehand, Aether
 - `AETHER_PEER` or `AETHER_WG_PEER` (`--peer`, `--wg-peer`) — if you want to give a fixed address yourself and bypass the scan.
 - `AETHER_CONFIG` (`--config`) — the path of the base config file. Default `aether.toml`.
 - `AETHER_WG_CONFIG` and `AETHER_MASQUE_CONFIG` (`--wg-config`, `--masque-config`) — the config path specific to each protocol.
+- `AETHER_WG_ENDPOINT_COOLDOWN_SECS` — how long an endpoint that fails twice is excluded from rescans. Default `300`.
 - `AETHER_TLS_GROUPS` (`--tls-groups`) — override the TLS key-share groups advertised in the handshake. Default mimics Chrome (`P-256:X25519:P-384`).
 
 ## Practical examples

--- a/Docs/GUIDE.fa.md
+++ b/Docs/GUIDE.fa.md
@@ -203,6 +203,7 @@ Reconnect to it now without rescanning? [Y/n]:
 - `AETHER_MASQUE_H2_FRAGMENT_DELAY` (`--fragment-delay`) — تأخیر بین تکه‌ها به میلی‌ثانیه، `n` یا `a-b`. پیش‌فرض `2-10`.
 - `AETHER_MASQUE_NO_DATA_CHECK` (`--no-data-check`) — اگه این رو بذاری، فقط `:status 200` کافیه؛ پروب end-to-end دیتاپلین انجام نمی‌شه.
 - `AETHER_MASQUE_VALIDATE_SECS` (`--validate-secs`) — چند ثانیه صبر کنه تا پروب دیتاپلین موفق بشه قبل از اینکه از یه گیت‌وی صرف‌نظر کنه. پیش‌فرض `10`.
+- `AETHER_MASQUE_STARTUP_SECS` (`--startup-secs`) — مهلت کلی برای اتصال TCP/QUIC، TLS، CONNECT-IP و تأیید اولیهٔ دیتاپلین. پیش‌فرض `30`.
 - `AETHER_MASQUE_RECONNECT_SECS` (`--reconnect-secs`) — تأخیر قبل از اتصال خودکار دوباره بعد از قطع تونل MASQUE یا شکست تأیید. پیش‌فرض `2`.
 - `AETHER_WG_RECONNECT_SECS` — تأخیر قبل از اتصال خودکار دوباره بعد از قطع تونل WireGuard. پیش‌فرض `2`.
 
@@ -221,6 +222,7 @@ Reconnect to it now without rescanning? [Y/n]:
 - `AETHER_PEER` یا `AETHER_WG_PEER` (`--peer`, `--wg-peer`) — اگه بخوای خودت یه آدرس ثابت بدی و اسکن رو دور بزنی.
 - `AETHER_CONFIG` (`--config`) — مسیر فایل کانفیگ پایه. پیش‌فرض `aether.toml`.
 - `AETHER_WG_CONFIG` و `AETHER_MASQUE_CONFIG` (`--wg-config`, `--masque-config`) — مسیر فایل کانفیگ مخصوص هر پروتکل.
+- `AETHER_WG_ENDPOINT_COOLDOWN_SECS` — مدت حذف موقت نقطه‌ای که دو بار پشت‌سرهم شکست خورده از اسکن‌ها. پیش‌فرض `300`.
 - `AETHER_TLS_GROUPS` (`--tls-groups`) — بازنویسی گروه‌های TLS key-share که توی دست‌دادن اعلام می‌شن. پیش‌فرض شبیه کروم هست (`P-256:X25519:P-384`).
 
 ## مثال‌های عملی

--- a/aether/src/cli.rs
+++ b/aether/src/cli.rs
@@ -36,6 +36,7 @@ MASQUE transport:
   --ech <auto|base64>      enable Encrypted Client Hello
   --no-data-check          skip the end-to-end data-plane validation
   --validate-secs <n>      seconds to wait for data-plane validation (default 10)
+  --startup-secs <n>       total MASQUE startup deadline (default 30)
   --reconnect-secs <n>     delay before reconnecting after a tunnel drop (default 2)
   --dns <list>             resolvers used inside the tunnel (default 1.1.1.1,1.0.0.1)
   --fragment               fragment the TLS ClientHello on the HTTP/2 transport
@@ -157,6 +158,7 @@ pub fn parse_and_apply() -> crate::error::Result<()> {
                 set("AETHER_MASQUE_VALIDATE_SECS", &value);
                 set("AETHER_WG_VALIDATE_SECS", &value);
             }
+            "--startup-secs" => set("AETHER_MASQUE_STARTUP_SECS", next_value!()),
             "--reconnect-secs" => {
                 let value = next_value!().clone();
                 set("AETHER_MASQUE_RECONNECT_SECS", &value);

--- a/aether/src/main.rs
+++ b/aether/src/main.rs
@@ -25,7 +25,9 @@ mod wg_prober;
 mod zerotrust;
 
 
+use std::collections::{HashMap, HashSet};
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::time::Instant;
 
 use error::{AetherError, Result};
 
@@ -516,6 +518,7 @@ async fn select_peer(identity: &account::Identity, protocol: Protocol) -> Result
                 aethernoize: aethernoize_config(),
                 ports: wireguard::WG_PORTS.to_vec(),
                 ip,
+                excluded: HashSet::new(),
             };
 
             let best = wg_prober::hunt_best_wg_endpoint(&probe, mode).await?;
@@ -559,6 +562,15 @@ fn masque_reconnect_delay() -> std::time::Duration {
         .ok()
         .and_then(|v| v.parse::<u64>().ok())
         .unwrap_or(2);
+    std::time::Duration::from_secs(secs)
+}
+
+fn masque_startup_timeout() -> std::time::Duration {
+    let secs = std::env::var("AETHER_MASQUE_STARTUP_SECS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .filter(|&v| v > 0)
+        .unwrap_or(30);
     std::time::Duration::from_secs(secs)
 }
 
@@ -825,9 +837,10 @@ async fn run_masque_tunnel(
         tokio::spawn(quic::run(cfg, internals, Some(addr_tx), Some(ready_tx)))
     };
 
-    match ready_rx.await {
-        Ok(()) => {}
-        Err(_) => {
+    let startup_timeout = masque_startup_timeout();
+    match tokio::time::timeout(startup_timeout, ready_rx).await {
+        Ok(Ok(())) => {}
+        Ok(Err(_)) => {
             let joined = tunnel_task.await;
             let msg = match joined {
                 Ok(Ok(())) => "tunnel exited before validation".to_string(),
@@ -835,6 +848,14 @@ async fn run_masque_tunnel(
                 Err(e) => format!("tunnel task join error: {e}"),
             };
             return Err(AetherError::Other(msg));
+        }
+        Err(_) => {
+            tunnel_task.abort();
+            let _ = tunnel_task.await;
+            return Err(AetherError::Other(format!(
+                "tunnel startup timed out after {:?}",
+                startup_timeout
+            )));
         }
     }
 
@@ -889,6 +910,7 @@ async fn hunt_wg_peer_with_profile(
     mode_str: &str,
     ip: prober::IpScan,
     profile: aethernoize::AetherNoizeConfig,
+    excluded: &HashSet<SocketAddr>,
 ) -> Result<SocketAddr> {
     let mode = wg_prober::WgScanMode::parse(mode_str);
     let private_key = identity.private_key_bytes()?;
@@ -905,6 +927,7 @@ async fn hunt_wg_peer_with_profile(
         aethernoize: profile,
         ports: wireguard::WG_PORTS.to_vec(),
         ip,
+        excluded: excluded.clone(),
     };
 
     let best = wg_prober::hunt_best_wg_endpoint(&probe, mode).await?;
@@ -919,18 +942,28 @@ fn wg_reconnect_delay() -> std::time::Duration {
     std::time::Duration::from_secs(secs)
 }
 
+fn wg_endpoint_cooldown() -> std::time::Duration {
+    let secs = std::env::var("AETHER_WG_ENDPOINT_COOLDOWN_SECS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .filter(|&v| v > 0)
+        .unwrap_or(300);
+    std::time::Duration::from_secs(secs)
+}
+
 async fn hunt_wg_peer(
     identity: &account::Identity,
     candidates: &[(String, aethernoize::AetherNoizeConfig)],
     mode_str: &str,
     ip: prober::IpScan,
+    excluded: &HashSet<SocketAddr>,
 ) -> Result<(SocketAddr, aethernoize::AetherNoizeConfig, String)> {
     let multi = candidates.len() > 1;
     for (name, profile) in candidates {
         log::info!(
             "[*] hunting for a working WireGuard endpoint (handshake + data-plane verification, aethernoize='{name}')"
         );
-        match hunt_wg_peer_with_profile(identity, mode_str, ip, profile.clone()).await {
+        match hunt_wg_peer_with_profile(identity, mode_str, ip, profile.clone(), excluded).await {
             Ok(peer) => {
                 log::info!("[+] selected WireGuard endpoint {peer} using aethernoize profile '{name}'");
                 return Ok((peer, profile.clone(), name.clone()));
@@ -1043,44 +1076,50 @@ async fn run_wireguard(identity: account::Identity, listen: SocketAddr, lastconn
 
     let mut last_good: Option<(SocketAddr, aethernoize::AetherNoizeConfig, String)> = None;
     let mut consecutive_fails_on_peer: u32 = 0;
+    let mut endpoint_cooldowns: HashMap<SocketAddr, Instant> = HashMap::new();
     const MAX_CONSECUTIVE_FAILS: u32 = 2;
 
     loop {
+        let now = Instant::now();
+        endpoint_cooldowns.retain(|_, until| *until > now);
+        if consecutive_fails_on_peer >= MAX_CONSECUTIVE_FAILS {
+            if let Some((peer, _, _)) = last_good.take() {
+                let cooldown = wg_endpoint_cooldown();
+                endpoint_cooldowns.insert(peer, now + cooldown);
+                log::warn!(
+                    "[-] endpoint {peer} failed {consecutive_fails_on_peer} times in a row; excluding it for {:?}",
+                    cooldown
+                );
+            }
+            consecutive_fails_on_peer = 0;
+        }
+
         let (peer, profile, profile_name) = if let Some(q) = quick.take() {
             q
         } else {
-            let retried = if consecutive_fails_on_peer >= MAX_CONSECUTIVE_FAILS {
-                if let Some((p, _, _)) = &last_good {
-                    log::warn!(
-                        "[-] endpoint {p} failed {consecutive_fails_on_peer} times in a row (likely DPI-throttled); blacklisting and rescanning"
-                    );
-                }
-                None
-            } else {
-                match &last_good {
-                    Some((p, profile, _)) => {
-                        log::info!("[*] retrying last known-good WireGuard endpoint {p} before rescanning");
-                        match wireguard::verify_endpoint(
-                            *p,
-                            private_key,
-                            peer_public,
-                            identity.client_id,
-                            ipv4,
-                            profile,
-                            std::time::Duration::from_secs(6),
-                            None,
-                        )
-                        .await
-                        {
-                            Ok(_) => Some(last_good.clone().unwrap()),
-                            Err(e) => {
-                                log::warn!("[-] last known-good endpoint {p} no longer responds ({e}); rescanning");
-                                None
-                            }
+            let retried = match &last_good {
+                Some((p, profile, _)) => {
+                    log::info!("[*] retrying last known-good WireGuard endpoint {p} before rescanning");
+                    match wireguard::verify_endpoint(
+                        *p,
+                        private_key,
+                        peer_public,
+                        identity.client_id,
+                        ipv4,
+                        profile,
+                        std::time::Duration::from_secs(6),
+                        None,
+                    )
+                    .await
+                    {
+                        Ok(_) => Some(last_good.clone().unwrap()),
+                        Err(e) => {
+                            log::warn!("[-] last known-good endpoint {p} no longer responds ({e}); rescanning");
+                            None
                         }
                     }
-                    None => None,
                 }
+                None => None,
             };
 
             match retried {
@@ -1122,7 +1161,9 @@ async fn run_wireguard(identity: account::Identity, listen: SocketAddr, lastconn
                             None => return Err(AetherError::NoCleanEndpoint),
                         }
                     } else {
-                        match hunt_wg_peer(&identity, &candidates, &mode_str, ip).await {
+                        let excluded: HashSet<SocketAddr> =
+                            endpoint_cooldowns.keys().copied().collect();
+                        match hunt_wg_peer(&identity, &candidates, &mode_str, ip, &excluded).await {
                             Ok(v) => v,
                             Err(e) => {
                                 log::warn!("[-] no usable WireGuard endpoint found: {e}; rescanning shortly");

--- a/aether/src/wg_prober.rs
+++ b/aether/src/wg_prober.rs
@@ -59,6 +59,8 @@ impl WgScanMode {
                 early_exit_first: true,
                 full_subnet: false,
                 sample_per_cidr: 40,
+                anchor_port_count: 4,
+                pool_port_waves: 2,
             },
             WgScanMode::Balanced => WgStrategy {
                 concurrency: 8,
@@ -69,6 +71,8 @@ impl WgScanMode {
                 early_exit_first: false,
                 full_subnet: false,
                 sample_per_cidr: 120,
+                anchor_port_count: 4,
+                pool_port_waves: 3,
             },
             WgScanMode::Thorough => WgStrategy {
                 concurrency: 10,
@@ -79,6 +83,8 @@ impl WgScanMode {
                 early_exit_first: false,
                 full_subnet: true,
                 sample_per_cidr: 0,
+                anchor_port_count: 8,
+                pool_port_waves: 4,
             },
             WgScanMode::Stealth => WgStrategy {
                 concurrency: 3,
@@ -89,6 +95,8 @@ impl WgScanMode {
                 early_exit_first: false,
                 full_subnet: false,
                 sample_per_cidr: 50,
+                anchor_port_count: 4,
+                pool_port_waves: 2,
             },
             WgScanMode::Ironclad => WgStrategy {
                 concurrency: 4,
@@ -99,6 +107,8 @@ impl WgScanMode {
                 early_exit_first: false,
                 full_subnet: false,
                 sample_per_cidr: 120,
+                anchor_port_count: 6,
+                pool_port_waves: 3,
             },
         }
     }
@@ -115,6 +125,8 @@ struct WgStrategy {
     early_exit_first: bool,
     full_subnet: bool,
     sample_per_cidr: usize,
+    anchor_port_count: usize,
+    pool_port_waves: usize,
 }
 
 #[derive(Clone)]
@@ -126,6 +138,7 @@ pub struct WgProbe {
     pub aethernoize: AetherNoizeConfig,
     pub ports: Vec<u16>,
     pub ip: IpScan,
+    pub excluded: HashSet<SocketAddr>,
 }
 
 pub async fn hunt_best_wg_endpoint(probe: &WgProbe, mode: WgScanMode) -> Result<WgProbeResult> {
@@ -142,7 +155,7 @@ pub async fn hunt_best_wg_endpoint(probe: &WgProbe, mode: WgScanMode) -> Result<
             return Err(AetherError::NoCleanEndpoint);
         }
     }
-    let candidates = build_wg_candidates(&st, &probe.ports, effective_ip);
+    let candidates = build_wg_candidates(&st, &probe.ports, effective_ip, &probe.excluded);
 
     log::info!(
         "[*] wireguard scan mode={} ip={} candidates={} ports={:?} concurrency={} per_probe={:?} budget={:?}",
@@ -292,7 +305,12 @@ async fn verify_one_wg(
     }
 }
 
-fn build_wg_candidates(st: &WgStrategy, ports: &[u16], ip: IpScan) -> Vec<(IpAddr, u16)> {
+fn build_wg_candidates(
+    st: &WgStrategy,
+    ports: &[u16],
+    ip: IpScan,
+    excluded: &HashSet<SocketAddr>,
+) -> Vec<(IpAddr, u16)> {
     let ports: Vec<u16> = {
         let mut seen_port: HashSet<u16> = HashSet::new();
         let deduped: Vec<u16> = ports.iter().copied().filter(|p| seen_port.insert(*p)).collect();
@@ -353,18 +371,30 @@ fn build_wg_candidates(st: &WgStrategy, ports: &[u16], ip: IpScan) -> Vec<(IpAdd
         }
     }
 
-    let mut ips: Vec<IpAddr> = Vec::with_capacity(anchors.len() + pool.len());
-    ips.extend(anchors.iter().copied());
-    ips.extend(pool.iter().copied());
-
     let mut out: Vec<(IpAddr, u16)> = Vec::new();
     let mut seen: HashSet<(IpAddr, u16)> = HashSet::new();
     let port_count = ports.len();
 
-    for (idx, a) in ips.iter().enumerate() {
-        let port = ports[idx % port_count];
-        if seen.insert((*a, port)) {
-            out.push((*a, port));
+    let mut push = |ip: IpAddr, port: u16| {
+        if !excluded.contains(&SocketAddr::new(ip, port)) && seen.insert((ip, port)) {
+            out.push((ip, port));
+        }
+    };
+
+    // Test known-good anchors on the documented priority ports before spending
+    // the scan budget on randomly sampled addresses.
+    for port in ports.iter().take(st.anchor_port_count.max(1)) {
+        for anchor in &anchors {
+            push(*anchor, *port);
+        }
+    }
+
+    // Cover the sampled pool in waves. Every address gets one attempt before a
+    // second port is tried, while successive waves rotate the assigned port.
+    for wave in 0..st.pool_port_waves.max(1) {
+        for (idx, candidate_ip) in pool.iter().enumerate() {
+            let port = ports[(idx + wave) % port_count];
+            push(*candidate_ip, port);
         }
     }
 
@@ -454,4 +484,75 @@ fn sample_cidr_v6(cidr: &str, n: usize, v4_cidrs: &[&str]) -> Vec<Ipv6Addr> {
         out.push(Ipv6Addr::from(base | embedded));
     }
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn anchors_cover_priority_ports_before_the_sampled_pool() {
+        let strategy = WgScanMode::Balanced.strategy();
+        let ports = [2408, 500, 1701, 4500, 854];
+        let candidates = build_wg_candidates(
+            &strategy,
+            &ports,
+            IpScan::V4,
+            &HashSet::new(),
+        );
+
+        for seed in wireguard::wg_seeds_v4() {
+            let ip = IpAddr::V4(seed.parse().expect("wireguard seed"));
+            for port in &ports[..4] {
+                assert!(
+                    candidates.contains(&(ip, *port)),
+                    "anchor {ip} should be tested on port {port}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn sampled_ips_receive_multiple_rotated_port_attempts() {
+        let mut strategy = WgScanMode::Balanced.strategy();
+        strategy.sample_per_cidr = 1;
+        let candidates = build_wg_candidates(
+            &strategy,
+            &[2408, 500, 1701, 4500],
+            IpScan::V4,
+            &HashSet::new(),
+        );
+        let anchors: HashSet<IpAddr> = wireguard::wg_seeds_v4()
+            .into_iter()
+            .map(|seed| IpAddr::V4(seed.parse().expect("wireguard seed")))
+            .collect();
+        let mut ports_per_ip: HashMap<IpAddr, HashSet<u16>> = HashMap::new();
+
+        for (ip, port) in candidates {
+            if !anchors.contains(&ip) {
+                ports_per_ip.entry(ip).or_default().insert(port);
+            }
+        }
+
+        assert!(
+            ports_per_ip.values().any(|ports| ports.len() >= 3),
+            "sampled IPs should be tried across multiple port waves"
+        );
+    }
+
+    #[test]
+    fn cooled_down_endpoint_is_excluded_from_the_scan() {
+        let strategy = WgScanMode::Turbo.strategy();
+        let peer: SocketAddr = "162.159.192.1:2408".parse().unwrap();
+        let excluded = HashSet::from([peer]);
+        let candidates = build_wg_candidates(
+            &strategy,
+            &[2408, 500, 1701, 4500],
+            IpScan::V4,
+            &excluded,
+        );
+
+        assert!(!candidates.contains(&(peer.ip(), peer.port())));
+    }
 }

--- a/aether/src/wireguard.rs
+++ b/aether/src/wireguard.rs
@@ -14,6 +14,10 @@ use rand::Rng;
 
 const TIMER_TICK: Duration = Duration::from_millis(250);
 const MAX_PACKET: usize = 65536;
+const VERIFY_RETRY_DELAYS: [Duration; 2] = [
+    Duration::from_millis(750),
+    Duration::from_millis(2_000),
+];
 
 const WG_MSG_TYPE_MIN: u8 = 1;
 const WG_MSG_TYPE_MAX: u8 = 4;
@@ -573,18 +577,25 @@ pub async fn verify_endpoint_keep_session(
     let mut recv_buf = vec![0u8; MAX_PACKET];
     let mut tmp_buf = vec![0u8; MAX_PACKET];
 
-    match tunn.encapsulate(&[], &mut out_buf) {
+    let init_packet = match tunn.encapsulate(&[], &mut out_buf) {
         TunnResult::WriteToNetwork(pkt) => {
             let mut pkt_vec = pkt.to_vec();
             inject_client_id(&mut pkt_vec, &client_id);
-            log::trace!("[wg] sending init {} bytes to {}", pkt_vec.len(), peer);
-            sock.send(&pkt_vec).await?;
+            pkt_vec
         }
         other => {
             log::warn!("[wg] unexpected encap result: {:?}", other);
             return Err(AetherError::Other("handshake init failed".into()));
         }
-    }
+    };
+
+    log::trace!("[wg] sending init {} bytes to {}", init_packet.len(), peer);
+    sock.send(&init_packet).await?;
+
+    let mut retry_index = 0usize;
+    let mut timer = tokio::time::interval(TIMER_TICK);
+    timer.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    timer.tick().await;
 
     let mut attempts = 0;
     loop {
@@ -651,6 +662,34 @@ pub async fn verify_endpoint_keep_session(
                     other => {
                         log::trace!("[wg] unexpected decap: {:?}", other);
                     }
+                }
+            }
+            _ = timer.tick() => {
+                if let Some(delay) = VERIFY_RETRY_DELAYS.get(retry_index) {
+                    if start.elapsed() >= *delay {
+                        retry_index += 1;
+                        log::trace!(
+                            "[wg] retransmitting init to {} after {:?} ({}/{})",
+                            peer,
+                            delay,
+                            retry_index,
+                            VERIFY_RETRY_DELAYS.len()
+                        );
+                        sock.send(&init_packet).await?;
+                    }
+                }
+
+                match tunn.update_timers(&mut out_buf) {
+                    TunnResult::WriteToNetwork(pkt) => {
+                        let mut pkt_vec = pkt.to_vec();
+                        inject_client_id(&mut pkt_vec, &client_id);
+                        log::trace!("[wg] timer generated {} byte handshake packet", pkt_vec.len());
+                        sock.send(&pkt_vec).await?;
+                    }
+                    TunnResult::Err(e) => {
+                        return Err(AetherError::Other(format!("wireguard timer failed: {e:?}")));
+                    }
+                    _ => {}
                 }
             }
             _ = tokio::time::sleep(remaining) => {
@@ -810,5 +849,42 @@ mod tests {
                 "{kind:?} should be fatal"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn endpoint_verification_retransmits_a_lost_initial_handshake() {
+        let server = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let peer = server.local_addr().unwrap();
+        let profile = aethernoize::from_profile("off");
+        let verifier = tokio::spawn(async move {
+            verify_endpoint(
+                peer,
+                [7u8; 32],
+                [9u8; 32],
+                [1u8, 2, 3],
+                "172.16.0.2".parse().unwrap(),
+                &profile,
+                Duration::from_secs(4),
+                None,
+            )
+            .await
+        });
+
+        let mut received = Vec::new();
+        let mut buf = [0u8; 2048];
+        for _ in 0..3 {
+            let n = tokio::time::timeout(Duration::from_secs(3), server.recv(&mut buf))
+                .await
+                .expect("handshake packet deadline")
+                .expect("handshake packet");
+            received.push(buf[..n].to_vec());
+        }
+
+        verifier.abort();
+        let _ = verifier.await;
+
+        assert_eq!(received.len(), 3);
+        assert_eq!(received[0], received[1]);
+        assert_eq!(received[1], received[2]);
     }
 }


### PR DESCRIPTION
Summary
Retransmit WireGuard verification handshakes when initial UDP packets are lost.
Test known endpoints across priority ports, then scan sampled addresses using rotated port waves.
Temporarily exclude repeatedly failing WireGuard endpoints from rescans.
Add a configurable timeout for MASQUE startup and initial validation.
Document the new settings in English and Persian.
Why
WireGuard verification previously sent only one handshake initiation, so a single lost packet could reject a working endpoint. The scanner also paired each address with only one port, potentially missing valid combinations.
Additionally, failed endpoints could be selected again despite being logged as blacklisted, while MASQUE startup had no outer timeout.
These changes improve connection probability and recovery on lossy, filtered, or frequently changing networks.
Validation
cargo check --locked
cargo test --locked — 138 passed, 0 failed, 2 ignored live-network tests
cargo build --locked
target/debug/aether.exe --version — aether 1.5.0