### PR TITLE
docs: fix build commands from repository root

### DIFF
--- a/Docs/DOCS.en.md
+++ b/Docs/DOCS.en.md
@@ -278,7 +278,10 @@ with a C API, so a host application can link the core instead of spawning it.
 This is what the iOS client needs, and it lets a Go program use Aether through
 cgo.
 
+From the repository root, enter the `aether` crate before building:
+
 ```sh
+cd aether
 cargo build --release            # binary and both libraries
 cargo build --release --bin aether   # binary only
 ```

--- a/Docs/DOCS.fa.md
+++ b/Docs/DOCS.fa.md
@@ -278,7 +278,10 @@ aether --masque --h2 --upstream http://proxy.example:8080
 به‌عنوان پروسه اجرا کند. کلاینت iOS به همین نیاز دارد، و یک برنامه‌ی Go هم
 می‌تواند از راه cgo از ایتر استفاده کند.
 
+از ریشهٔ مخزن ابتدا وارد کریت `aether` شوید:
+
 ```sh
+cd aether
 cargo build --release                # باینری و هر دو کتابخانه
 cargo build --release --bin aether   # فقط باینری
 ```

--- a/README.fa.md
+++ b/README.fa.md
@@ -66,16 +66,17 @@ aether
   quiche/
 ```
 
-ساخت پروژه:
+ساخت پروژه از ریشهٔ مخزن:
 
 ```bash
+cd aether
 cargo build --release
 ```
 
-فایل نهایی:
+فایل نهایی در مسیر زیر ساخته می‌شود:
 
 ```text
-target/release/aether
+aether/target/release/aether
 ```
 
 ## داکر (Docker)
@@ -113,18 +114,18 @@ docker run -it -p 127.0.0.1:1819:1819 -v aether-data:/data aether
 برنامه را بدون هیچ آرگومانی اجرا کنید و به سؤال‌ها جواب بدید:
 
 ```bash
-./target/release/aether
+./aether/target/release/aether
 ```
 
 یا با پرچم‌ها از سؤال‌ها رد شید:
 
 ```bash
-./target/release/aether --masque -4 --scan turbo --noize firewall
+./aether/target/release/aether --masque -4 --scan turbo --noize firewall
 ```
 
 روی ویندوز، به‌جای اون کافیه روی `run-aether.bat` (که همراه zip ریلیز میاد) دابل‌کلیک کنی — یه ترمینال باز می‌کنه، `aether.exe` رو اجرا می‌کنه، و بعدش پنجره رو باز نگه می‌داره تا هر خطایی رو بتونی بخونی.
 
-هر سؤال یه پرچم و یه متغیر محیطی معادل داره. برای لیست کامل `./target/release/aether --help` رو بزن، یا به راهنماهای پایین‌تر مراجعه کن.
+هر سؤال یه پرچم و یه متغیر محیطی معادل داره. برای لیست کامل `./aether/target/release/aether --help` رو بزن، یا به راهنماهای پایین‌تر مراجعه کن.
 
 پس از اجرا، پراکسی SOCKS5 روی آدرس زیر در دسترس خواهد بود:
 

--- a/README.md
+++ b/README.md
@@ -64,16 +64,17 @@ The `quiche` repository must be placed alongside `aether`:
   quiche/
 ```
 
-Build:
+Build from the repository root:
 
 ```bash
+cd aether
 cargo build --release
 ```
 
-Binary:
+The binary is written to:
 
 ```text
-target/release/aether
+aether/target/release/aether
 ```
 
 ## Docker
@@ -111,18 +112,18 @@ docker run -it -p 127.0.0.1:1819:1819 -v aether-data:/data aether
 Run with no arguments and answer the prompts:
 
 ```bash
-./target/release/aether
+./aether/target/release/aether
 ```
 
 Or skip the prompts with flags:
 
 ```bash
-./target/release/aether --masque -4 --scan turbo --noize firewall
+./aether/target/release/aether --masque -4 --scan turbo --noize firewall
 ```
 
 On Windows, double-click `run-aether.bat` (included in the release zip) instead — it opens a terminal, runs `aether.exe`, and keeps the window open afterwards so you can read any errors.
 
-Every prompt has a flag and an environment variable equivalent. Run `./target/release/aether --help` for the full list, or see the guides linked below.
+Every prompt has a flag and an environment variable equivalent. Run `./aether/target/release/aether --help` for the full list, or see the guides linked below.
 
 After startup, a SOCKS5 proxy will be available at:
 


### PR DESCRIPTION
## Summary

The repository's build instructions currently omit the required `aether` working directory even though the root checkout has no `Cargo.toml`.

This PR:

- Adds `cd aether` before build commands in the English and Persian README files.
- Corrects the documented binary path to `aether/target/release/aether` when commands are run from the repository root.
- Adds the same working-directory clarification to the detailed English and Persian library-build documentation.

## Why

Following the previous root-level instructions from a fresh checkout leads users to invoke Cargo without a manifest. The corrected commands match the actual repository layout and the Dockerfile's existing `/usr/src/app/aether` working directory.

## Validation

- `git diff --check` passes.
- Confirmed the only Rust manifests are under `aether/` and `quiche/`.
- Confirmed this PR changes documentation only.
- A full Cargo build was not run in the validation environment because Rust/Cargo is not installed there.

Closes #83