### PR TITLE
scanner: faster reconnects, better MASQUE port coverage, cheap reachability pre-filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,62 +1,135 @@
 # Aether
 
+[![GitHub release](https://img.shields.io/github/v/release/CluvexStudio/Aether)](https://github.com/CluvexStudio/Aether/releases)
+[![Platform](https://img.shields.io/badge/platform-linux%20%7C%20windows%20%7C%20macos%20%7C%20android-lightgrey)](https://github.com/CluvexStudio/Aether/releases)
+[![Rust](https://img.shields.io/badge/rust-1.91%2B-orange)](https://www.rust-lang.org)
+[![License](https://img.shields.io/badge/license-AGPL--3.0--only-blue)](LICENSE)
+
 ![Aether](Docs/Aether.png)
 
-### اینترنت آزاد برای همه:))
-**[راهنمای فارسی](README.fa.md)** · **[English Guide](Docs/DOCS.en.md)** · **[راهنمای کامل فارسی](Docs/DOCS.fa.md)**
+### اینترنت آزاد برای همه :))
+
+**[راهنمای فارسی](README.fa.md)** · **[English guide](Docs/GUIDE.en.md)** · **[راهنمای کامل فارسی](Docs/GUIDE.fa.md)** · **[Reference (EN)](Docs/DOCS.en.md)** · **[مرجع کامل (FA)](Docs/DOCS.fa.md)**
 
 Telegram: https://t.me/CluvexStudio
 
-Aether is a censorship circumvention client designed for heavily restricted networks. It automatically discovers reachable routes, establishes an encrypted tunnel, and exposes a local SOCKS5 proxy for your applications.
+Aether is a censorship-circumvention client built for heavily restricted networks. It automatically discovers reachable routes, proves each one with real end-to-end traffic before trusting it, then serves the tunnel as a local SOCKS5 proxy for your applications.
 
-Unlike traditional VPN clients, Aether is built for environments where Deep Packet Inspection (DPI), protocol fingerprinting, UDP throttling, and endpoint blocking are common.
+Unlike traditional VPN clients, Aether assumes Deep Packet Inspection, protocol fingerprinting, UDP throttling, and endpoint blocking — and keeps working through them.
+
+## Contents
+
+- [Features](#features)
+- [Quickstart](#quickstart)
+- [Scan modes](#scan-modes)
+- [Protocols](#protocols)
+- [Configuration](#configuration)
+- [Install](#install)
+- [Build from source](#build-from-source)
+- [Docker](#docker)
+- [Testing](#testing)
+- [Documentation](#documentation)
+- [Security notes](#security-notes)
+- [Contributing](#contributing)
+- [Donate](#donate)
+- [License](#license)
+- [Credits](#credits)
 
 ## Features
 
-- Automatic endpoint discovery, with end-to-end data-plane validation so a gateway is only trusted once it actually passes traffic, not just once it answers the handshake
-- MASQUE (HTTP/3 & HTTP/2), with optional TLS ClientHello fragmentation on HTTP/2
-- WireGuard support
-- Nested WireGuard mode (`gool`), with both hops discovered by the scan or given by hand
-- Traffic obfuscation
-- Routing rules by domain, address, or port, matched from the TLS server name so they keep working behind a tun front end
-- Upstream proxy support, so Aether can dial out through another VPN or proxy already running on the machine
-- Automatic reconnection, and quick-reconnect to your last known-good gateway to skip rescanning
-- Local SOCKS5 proxy
-- Command-line flags, environment variables, or interactive prompts — your choice
-- Linux, Windows, macOS and Android (Termux)
+- **Validated scanning** — a gateway is trusted only after it carries real traffic, never just for answering a handshake; recent winners are remembered so reconnects usually skip the scan entirely
+- **MASQUE** over HTTP/3 (QUIC) and HTTP/2 (TCP), with optional TLS ClientHello fragmentation on the HTTP/2 transport
+- **WireGuard**, plus nested WireGuard (`gool`, warp-in-warp) with both hops discovered or hand-picked
+- **Traffic obfuscation** profiles (`off` → `aggressive`) tuned per transport
+- **Routing rules** by domain, address, or port, matched from the TLS server name so they keep working behind a tun front end
+- **Upstream proxy support** — dial out through another VPN or proxy already running on the machine
+- **Automatic reconnection** with quick-reconnect to the last known-good gateway
+- **Local SOCKS5 proxy**, no authentication, bound to loopback by default
+- Flags, environment variables, or interactive prompts — every prompt has both
+- Linux, Windows, macOS, Android (Termux)
 
-## Download
+## Quickstart
 
-Prebuilt binaries are available on the Releases page for:
-
-- Linux
-- Windows
-- macOS
-- Android (Termux)
-
-### Termux (Android) — one-line install
+Answer the prompts:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/CluvexStudio/aether/main/aether.sh -o aether.sh && chmod +x aether.sh && ./aether.sh install
+./aether
 ```
 
-This detects your device architecture, downloads the matching release, verifies its checksum, and installs `aether` into `$PREFIX/bin`. Run it afterwards with:
+Or skip them:
 
 ```bash
-aether
+./aether --masque -4 --scan turbo --noize firewall
 ```
 
-To update later, run `./aether.sh update`. To remove it, run `./aether.sh uninstall`.
+On Windows, double-click `run-aether.bat` from the release zip instead — it keeps the window open so you can read any errors.
 
-## Build
+Verify the tunnel (expect `warp=on`):
 
-### Requirements
+```bash
+curl -x socks5h://127.0.0.1:1819 https://www.cloudflare.com/cdn-cgi/trace
+```
 
-- Rust 1.91 or newer
-- C/C++ compiler
-- CMake
+Run `aether help` for the full reference — every flag, every variable, what each one does.
 
-The `quiche` repository must be placed alongside `aether`:
+## Scan modes
+
+| Mode | Behavior | Reach for it when… |
+|---|---|---|
+| `turbo` | First responder wins | You want the fastest connect |
+| `balanced` *(default)* | Collects a few, keeps the fastest | Everyday use |
+| `thorough` | Sweeps whole subnets | Nothing else finds a route |
+| `stealth` | Minimal in-flight probes | The network notices scanning |
+| `ironclad` | A real HTTP request per candidate | You need maximum certainty |
+
+Related knobs: `--peer` / `--wiw-outer` / `--wiw-inner` pin endpoints and skip scanning; `--no-quick-reconnect` forces a fresh sweep; `AETHER_PROBE_JITTER_MS` smooths probe bursts on hostile networks.
+
+## Protocols
+
+### MASQUE (recommended)
+
+Traffic encapsulated over HTTP/3 (QUIC) or HTTP/2 (TLS) — it looks like ordinary HTTPS.
+
+### WireGuard
+
+Fast, lightweight transport for networks with less aggressive inspection.
+
+### Nested WireGuard (`gool`)
+
+A WireGuard tunnel inside another WireGuard tunnel — an extra encryption layer. Both hops are found by the scan by default; if you already know addresses that work, name them:
+
+```bash
+./aether --gool --wiw-outer 162.159.192.1:2408 --wiw-inner 188.114.96.1:2408
+```
+
+The port is required — which port gets through is exactly what differs between networks, so none is assumed. Name one hop and the scan finds the other.
+
+## Configuration
+
+Three equivalent ways, pick one per setting: interactive prompt, `--flag`, or `AETHER_*` environment variable. Examples:
+
+```bash
+export AETHER_PROTOCOL=masque AETHER_SCAN=balanced AETHER_NOIZE=firewall
+./aether
+```
+
+The proxy listens on `--bind` (`127.0.0.1:1819` by default). Identities live next to the config files (`aether.toml`, plus `-wg` / `-masque` variants) — back them up; re-registering too often gets rate-limited.
+
+## Install
+
+Prebuilt binaries on the [Releases](https://github.com/CluvexStudio/Aether/releases) page for Linux, Windows, macOS, and Android (Termux).
+
+### Termux — one line
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/CluvexStudio/Aether/main/aether.sh -o aether.sh && chmod +x aether.sh && ./aether.sh install
+```
+
+Afterwards just run `aether`. Update with `./aether.sh update`, remove with `./aether.sh uninstall`.
+
+## Build from source
+
+Requirements: Rust 1.91+, a C/C++ compiler, CMake — plus the `quiche` checkout placed alongside `aether`:
 
 ```text
 <repo>/
@@ -64,33 +137,22 @@ The `quiche` repository must be placed alongside `aether`:
   quiche/
 ```
 
-Build:
-
 ```bash
 cargo build --release
-```
-
-Binary:
-
-```text
-target/release/aether
+# binary: aether/target/release/aether
 ```
 
 ## Docker
 
-You can run Aether in an isolated environment using Docker. The official image is available on GitHub Container Registry (GHCR).
+> **The SOCKS5 proxy has no authentication.** Every command below publishes the port to `127.0.0.1` only. Never use `-p 1819:1819` (all interfaces = open relay). To serve other machines, put an authenticated front end in front and firewall the port.
 
-> **The SOCKS5 proxy has no authentication.** Anyone who can reach the port can use your tunnel. Every command below publishes the port to `127.0.0.1` only, so it stays reachable from your own machine and nothing else. Do not replace it with `-p 1819:1819`, because that form listens on every interface of the host and turns the proxy into an open relay. If you genuinely need to serve other machines, put an authenticated front end in front of it and firewall the port.
-
-The `-v aether-data:/data` volume keeps the generated WARP identity between runs. Without it every start registers a brand new device, and Cloudflare begins rate limiting your address.
-
-Pull and run the pre-built image (interactive mode is required for initial setup):
+The `-v aether-data:/data` volume keeps the generated WARP identity between runs — without it every start registers a new device and Cloudflare rate-limits your address.
 
 ```bash
 docker run -it -p 127.0.0.1:1819:1819 -v aether-data:/data ghcr.io/cluvexstudio/aether:latest
 ```
 
-You can also bypass prompts by providing environment variables:
+Headless with environment variables:
 
 ```bash
 docker run -it -p 127.0.0.1:1819:1819 -v aether-data:/data \
@@ -99,78 +161,45 @@ docker run -it -p 127.0.0.1:1819:1819 -v aether-data:/data \
   ghcr.io/cluvexstudio/aether:latest
 ```
 
-If you prefer to build the image manually from source:
+Or build it yourself:
 
 ```bash
 docker build -t aether .
 docker run -it -p 127.0.0.1:1819:1819 -v aether-data:/data aether
 ```
 
-## Usage
-
-Run with no arguments and answer the prompts:
+## Testing
 
 ```bash
-./target/release/aether
+cargo test
 ```
 
-Or skip the prompts with flags:
+Unit tests run offline. A few live network probes exist for characterizing new networks but stay `#[ignore]`d by default — run one explicitly only when you mean to touch the wire:
 
 ```bash
-./target/release/aether --masque -4 --scan turbo --noize firewall
+cargo test -- --ignored report_which_masque_ranges_answer_on_this_network
 ```
-
-On Windows, double-click `run-aether.bat` (included in the release zip) instead — it opens a terminal, runs `aether.exe`, and keeps the window open afterwards so you can read any errors.
-
-Every prompt has a flag and an environment variable equivalent. Run `aether help` (or `--help`) for the full list — every flag, every variable, and what each one does — or see the guides linked below.
-
-After startup, a SOCKS5 proxy will be available at:
-
-```
-127.0.0.1:1819
-```
-
-Example:
-
-```bash
-curl -x socks5h://127.0.0.1:1819 https://www.cloudflare.com/cdn-cgi/trace
-```
-
-## Supported Protocols
-
-### MASQUE (Recommended)
-
-Encapsulates traffic over HTTP/3 (QUIC) or HTTP/2 (TLS), making it resemble ordinary HTTPS traffic.
-
-### WireGuard
-
-Fast and lightweight transport for networks with less aggressive inspection.
-
-### Nested WireGuard (`gool`)
-
-A WireGuard tunnel running inside another WireGuard tunnel, providing an additional encryption layer.
-
-Its two hops are found by the scan by default. If you already know addresses that work on your network, name them instead with `--wiw-outer 162.159.192.1:2408 --wiw-inner 188.114.96.1:2408`, or both at once with `--wiw-peers 162.159.192.1:2408,188.114.96.1:2408`. The port is required — which port gets through is what differs between networks, so none is assumed. Give only one and the scan finds the other.
 
 ## Documentation
 
-Detailed documentation is available in:
+- [Docs/GUIDE.en.md](Docs/GUIDE.en.md) — complete English guide
+- [Docs/GUIDE.fa.md](Docs/GUIDE.fa.md) — راهنمای کامل فارسی
+- [Docs/DOCS.en.md](Docs/DOCS.en.md) — command/environment reference (EN)
+- [Docs/DOCS.fa.md](Docs/DOCS.fa.md) — مرجع کامل دستورات و متغیرها (FA)
 
-- [Docs/GUIDE.en.md](Docs/GUIDE.en.md) — English guide
-- [Docs/GUIDE.fa.md](Docs/GUIDE.fa.md) — راهنمای فارسی
+## Security notes
 
-## Credits
-
-Developed by **CluvexStudio**. :))
-
-MASQUE support is built on top of Cloudflare's **Quiche** library.
-
+- The SOCKS proxy has **no authentication** — keep it on loopback.
+- Identities (`aether*.toml`) are device credentials — treat them like passwords and don't share them.
+- `--upstream` sends your traffic through another local proxy first; make sure you trust it.
 
 ## Contributing
 
 > **Experienced network developers and protocol engineers are welcome to contribute.**
 
 > **Please keep the codebase clean, maintainable, and well-engineered. Low-quality or vibe-coded contributions will not be accepted.**
+
+Run `cargo test` before every pull request. Live-network tests stay ignored unless the change is specifically about them.
 
 ## Donate
 
@@ -182,4 +211,10 @@ If Aether has been useful to you, consider supporting its development:
 
 ## License
 
-See the LICENSE file for licensing information.
+AGPL-3.0-only — see [LICENSE](LICENSE).
+
+## Credits
+
+Developed by **CluvexStudio**. :))
+
+MASQUE support is built on top of Cloudflare's **Quiche** library.

--- a/aether/src/cli.rs
+++ b/aether/src/cli.rs
@@ -191,6 +191,8 @@ Environment variables:
                                    out of rescans (default 300)
   AETHER_WG_STALE_SECS             silence on a wireguard tunnel before it counts
                                    as dead (default 10)
+  AETHER_PROBE_JITTER_MS           max random delay per probe, smooths scan
+                                   bursts on hostile networks (default 0)
   AETHER_MASQUE_H2_KEEPALIVE_SECS  HTTP/2 keepalive interval (default 15)
   AETHER_MASQUE_H2_KEEPALIVE_TIMEOUT_SECS
                                    how long a keepalive may go unanswered (default 20)

--- a/aether/src/lastconn.rs
+++ b/aether/src/lastconn.rs
@@ -1,10 +1,18 @@
 use serde::{Deserialize, Serialize};
+use std::net::SocketAddr;
+
+/// How many recently-working endpoints are remembered for the fast path.
+pub const RECENT_CAP: usize = 8;
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct LastConnection {
     pub peer: String,
     #[serde(default)]
     pub profile: String,
+    /// Most-recent-first ring of working `ip:port`s. Old files simply lack
+    /// it and load as empty, so this stays backward compatible.
+    #[serde(default)]
+    pub recent: Vec<String>,
 }
 
 pub fn load(path: &str) -> Option<LastConnection> {
@@ -13,9 +21,14 @@ pub fn load(path: &str) -> Option<LastConnection> {
 }
 
 pub fn save(path: &str, peer: &str, profile: &str) {
+    let mut recent = load(path).map(|c| c.recent).unwrap_or_default();
+    recent.retain(|p| p != peer);
+    recent.insert(0, peer.to_string());
+    recent.truncate(RECENT_CAP);
     let conn = LastConnection {
         peer: peer.to_string(),
         profile: profile.to_string(),
+        recent,
     };
     match toml::to_string_pretty(&conn) {
         Ok(text) => {
@@ -24,5 +37,76 @@ pub fn save(path: &str, peer: &str, profile: &str) {
             }
         }
         Err(e) => log::debug!("[lastconn] failed to encode: {e}"),
+    }
+}
+
+/// Parsed, most-recent-first candidates for the reconnect fast path.
+pub fn recent_peers(cached: &LastConnection) -> Vec<SocketAddr> {
+    let mut out = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+    for raw in std::iter::once(&cached.peer).chain(cached.recent.iter()) {
+        if let Ok(addr) = raw.parse::<SocketAddr>() {
+            if seen.insert(addr) {
+                out.push(addr);
+            }
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tmp_path(tag: &str) -> String {
+        let mut p = std::env::temp_dir();
+        p.push(format!("aether-lastconn-test-{tag}-{}.toml", std::process::id()));
+        let _ = std::fs::remove_file(&p);
+        p.to_string_lossy().to_string()
+    }
+
+    #[test]
+    fn save_builds_a_most_recent_first_ring() {
+        let path = tmp_path("ring");
+        save(&path, "1.1.1.1:443", "gfw");
+        save(&path, "1.0.0.1:443", "gfw");
+        save(&path, "1.1.1.1:443", "gfw");
+        let loaded = load(&path).expect("saved file must load");
+        assert_eq!(loaded.peer, "1.1.1.1:443", "peer stays the latest");
+        assert_eq!(loaded.recent, vec!["1.1.1.1:443", "1.0.0.1:443"]);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn ring_is_capped_and_deduped() {
+        let path = tmp_path("cap");
+        for i in 0..20u8 {
+            save(&path, &format!("10.0.0.{i}:443"), "balanced");
+        }
+        let loaded = load(&path).expect("saved file must load");
+        assert_eq!(loaded.recent.len(), RECENT_CAP);
+        assert_eq!(loaded.recent[0], "10.0.0.19:443");
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn old_files_without_recent_still_load() {
+        let path = tmp_path("legacy");
+        std::fs::write(&path, "peer = \"1.1.1.1:443\"\nprofile = \"gfw\"\n").unwrap();
+        let loaded = load(&path).expect("legacy file must load");
+        assert_eq!(loaded.peer, "1.1.1.1:443");
+        assert!(loaded.recent.is_empty());
+        assert_eq!(recent_peers(&loaded), vec!["1.1.1.1:443".parse().unwrap()]);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn recent_peers_skips_garbage_and_dupes() {
+        let cached = LastConnection {
+            peer: "not-an-addr".to_string(),
+            profile: String::new(),
+            recent: vec!["1.1.1.1:443".to_string(), "1.1.1.1:443".to_string()],
+        };
+        assert_eq!(recent_peers(&cached), vec!["1.1.1.1:443".parse().unwrap()]);
     }
 }

--- a/aether/src/lib.rs
+++ b/aether/src/lib.rs
@@ -1055,15 +1055,21 @@ async fn run_masque(
 
     if forced.is_none() && quick_peer.is_none() {
         if let Some(cached) = lastconn::load(&lastconn_path) {
-            if let Ok(peer) = cached.peer.parse::<SocketAddr>() {
-                if want_quick_reconnect(&cached).await {
+            // Fast path over the recent-winners ring, newest first: a
+            // reconnect that hits usually skips the whole scan in seconds.
+            let ring = lastconn::recent_peers(&cached);
+            if !ring.is_empty() && want_quick_reconnect(&cached).await {
+                for peer in ring {
                     log::info!("[*] verifying cached gateway {peer} before reuse");
                     if quick_verify_masque_peer(&identity, peer).await {
                         log::info!("[+] cached gateway {peer} still works; skipping scan");
                         quick_peer = Some(peer);
-                    } else {
-                        log::warn!("[-] cached gateway {peer} no longer works; scanning fresh");
+                        break;
                     }
+                    log::warn!("[-] cached gateway {peer} no longer works; trying next recent one");
+                }
+                if quick_peer.is_none() {
+                    log::warn!("[-] no recent gateway answers; scanning fresh");
                 }
             }
         }
@@ -1418,8 +1424,9 @@ async fn run_wireguard(identity: account::Identity, listen: SocketAddr, lastconn
 
     if forced.is_none() && quick.is_none() {
         if let Some(cached) = lastconn::load(&lastconn_path) {
-            if let Ok(peer) = cached.peer.parse::<SocketAddr>() {
-                if want_quick_reconnect(&cached).await {
+            let ring = lastconn::recent_peers(&cached);
+            if !ring.is_empty() && want_quick_reconnect(&cached).await {
+                for peer in ring {
                     let profile = aethernoize::from_profile(&cached.profile);
                     log::info!("[*] verifying cached WireGuard endpoint {peer} before reuse");
                     match wireguard::verify_endpoint(
@@ -1437,11 +1444,15 @@ async fn run_wireguard(identity: account::Identity, listen: SocketAddr, lastconn
                         Ok(rtt) => {
                             log::info!("[+] cached endpoint {peer} still works (rtt {:?}); skipping scan", rtt);
                             quick = Some((peer, profile, cached.profile.clone()));
+                            break;
                         }
                         Err(e) => {
-                            log::warn!("[-] cached endpoint {peer} no longer works ({e}); scanning fresh");
+                            log::warn!("[-] cached endpoint {peer} no longer works ({e}); trying next recent one");
                         }
                     }
+                }
+                if quick.is_none() {
+                    log::warn!("[-] no recent endpoint answers; scanning fresh");
                 }
             }
         }

--- a/aether/src/prober.rs
+++ b/aether/src/prober.rs
@@ -368,6 +368,16 @@ async fn verify_one(
     timeout: Duration,
     ironclad: bool,
 ) -> Option<ProbeResult> {
+    paced_probe_start().await;
+    if !ironclad {
+        // Stage 1: cheap reachability. Hosts that answer nothing die here
+        // in ~1 RTT instead of burning a full crypto-handshake timeout.
+        let peer = SocketAddr::new(ip, port);
+        if !cheap_initial_reply(peer, crate::masque_h2::enabled(), prefilter_timeout(timeout)).await
+        {
+            return None;
+        }
+    }
     if ironclad {
         let params = crate::tunnelping::MasquePingParams {
             peer: SocketAddr::new(ip, port),
@@ -438,18 +448,27 @@ async fn verify_one(
 }
 
 fn build_candidates(st: &Strategy, ports: &[u16], ip: IpScan) -> Vec<(IpAddr, u16)> {
-    let primary = ports.first().copied().unwrap_or(443);
+    let fallback = [443u16];
+    let ports: &[u16] = if ports.is_empty() { &fallback } else { ports };
+    let primary = ports[0];
     let mut out: Vec<(IpAddr, u16)> = Vec::new();
     let mut seen: HashSet<(IpAddr, u16)> = HashSet::new();
+
+    let mut push = |ip: IpAddr, port: u16| {
+        if seen.insert((ip, port)) {
+            out.push((ip, port));
+        }
+    };
 
     let seeds: Vec<Ipv4Addr> = MASQUE_SEEDS.iter().filter_map(|s| s.parse().ok()).collect();
     let seeds6: Vec<Ipv6Addr> = MASQUE_SEEDS_V6.iter().filter_map(|s| s.parse().ok()).collect();
 
+    // Ordered IP list: anchors first, then the pool round-robin across
+    // CIDRs (same head order as before — the most likely responders lead).
+    let mut ips: Vec<IpAddr> = Vec::new();
     if ip.want_v4() {
         for a in &seeds {
-            if seen.insert((IpAddr::V4(*a), primary)) {
-                out.push((IpAddr::V4(*a), primary));
-            }
+            ips.push(IpAddr::V4(*a));
         }
         let cidr_hosts: Vec<Vec<Ipv4Addr>> = masque_cidrs_v4()
             .iter()
@@ -465,9 +484,7 @@ fn build_candidates(st: &Strategy, ports: &[u16], ip: IpScan) -> Vec<(IpAddr, u1
         for i in 0..max_len {
             for hosts in &cidr_hosts {
                 if let Some(a) = hosts.get(i) {
-                    if seen.insert((IpAddr::V4(*a), primary)) {
-                        out.push((IpAddr::V4(*a), primary));
-                    }
+                    ips.push(IpAddr::V4(*a));
                 }
             }
         }
@@ -475,9 +492,7 @@ fn build_candidates(st: &Strategy, ports: &[u16], ip: IpScan) -> Vec<(IpAddr, u1
 
     if ip.want_v6() {
         for a in &seeds6 {
-            if seen.insert((IpAddr::V6(*a), primary)) {
-                out.push((IpAddr::V6(*a), primary));
-            }
+            ips.push(IpAddr::V6(*a));
         }
         let per = if st.sample_per_cidr == 0 { 96 } else { st.sample_per_cidr };
         let cidr6: Vec<Vec<Ipv6Addr>> = masque_cidrs_v6()
@@ -488,19 +503,30 @@ fn build_candidates(st: &Strategy, ports: &[u16], ip: IpScan) -> Vec<(IpAddr, u1
         for i in 0..max6 {
             for hosts in &cidr6 {
                 if let Some(a) = hosts.get(i) {
-                    if seen.insert((IpAddr::V6(*a), primary)) {
-                        out.push((IpAddr::V6(*a), primary));
-                    }
+                    ips.push(IpAddr::V6(*a));
                 }
             }
         }
     }
 
+    // Wave 0: the ordered list on rotated ports, so the scan head spreads
+    // across ports instead of hammering 443 (same shape as the WG sweep).
+    // Wave 1: every address once more on its next rotated port — a pool host
+    // that only answers off-primary is found up front instead of never.
+    let n = ports.len();
+    for wave in 0..n.min(2) {
+        for (idx, candidate_ip) in ips.iter().enumerate() {
+            // `seen` dedups; the two waves never collide for n > 1.
+            push(*candidate_ip, ports[(idx + wave) % n]);
+        }
+    }
+
+    // Anchors keep full multi-port coverage (as before).
     if ip.want_v4() {
         for a in &seeds {
             for &port in ports {
-                if port != primary && seen.insert((IpAddr::V4(*a), port)) {
-                    out.push((IpAddr::V4(*a), port));
+                if port != primary {
+                    push(IpAddr::V4(*a), port);
                 }
             }
         }
@@ -508,8 +534,8 @@ fn build_candidates(st: &Strategy, ports: &[u16], ip: IpScan) -> Vec<(IpAddr, u1
     if ip.want_v6() {
         for a in &seeds6 {
             for &port in ports {
-                if port != primary && seen.insert((IpAddr::V6(*a), port)) {
-                    out.push((IpAddr::V6(*a), port));
+                if port != primary {
+                    push(IpAddr::V6(*a), port);
                 }
             }
         }
@@ -603,6 +629,89 @@ fn sample_cidr_v6(cidr: &str, n: usize, v4_cidrs: &[&str]) -> Vec<Ipv6Addr> {
     out
 }
 
+/// Cheap reachability pre-filter: one handshake-less probe before paying
+/// for a full verify. A bare QUIC Initial (or a TCP SYN in H2 mode) that
+/// gets ANY reply means someone lives there; silence means skip without
+/// burning crypto + multi-RTT handshake timeouts on a dead host.
+///
+/// Deliberately no obfuscation noise here: answering an Initial is mandatory
+/// for a real QUIC edge, and the noise sleeps would defeat the "cheap" part.
+/// The full verify that follows still decides; this only skips the silent.
+async fn cheap_initial_reply(peer: SocketAddr, h2: bool, timeout: Duration) -> bool {
+    if h2 {
+        tcp_answers(peer, timeout).await.is_some()
+    } else {
+        quic_answers(peer, timeout).await.is_some()
+    }
+}
+
+async fn quic_answers(peer: SocketAddr, timeout: Duration) -> Option<Duration> {
+    let bind = if peer.is_ipv4() { "0.0.0.0:0" } else { "[::]:0" };
+    let sock = tokio::net::UdpSocket::bind(bind).await.ok()?;
+    sock.connect(peer).await.ok()?;
+    let local = sock.local_addr().ok()?;
+
+    let mut config = quiche::Config::new(quiche::PROTOCOL_VERSION).ok()?;
+    config.set_application_protos(&[b"h3"]).ok()?;
+    config.verify_peer(false);
+    config.set_max_idle_timeout(timeout.as_millis() as u64);
+    config.set_initial_max_data(1_000_000);
+    config.set_initial_max_stream_data_bidi_local(100_000);
+    config.set_initial_max_streams_bidi(4);
+
+    let mut scid = [0u8; 16];
+    rand::rng().fill(&mut scid[..]);
+    let scid = quiche::ConnectionId::from_ref(&scid);
+
+    let sni = crate::consts::CONNECT_SNI;
+    let mut conn = quiche::connect(Some(sni), &scid, local, peer, &mut config).ok()?;
+
+    let mut out = [0u8; 1350];
+    let (written, _) = conn.send(&mut out).ok()?;
+
+    let started = Instant::now();
+    sock.send(&out[..written]).await.ok()?;
+
+    let mut buf = [0u8; 1500];
+    match tokio::time::timeout(timeout, sock.recv(&mut buf)).await {
+        Ok(Ok(read)) if read > 0 => Some(started.elapsed()),
+        _ => None,
+    }
+}
+
+async fn tcp_answers(peer: SocketAddr, timeout: Duration) -> Option<Duration> {
+    let started = Instant::now();
+    match tokio::time::timeout(timeout, tokio::net::TcpStream::connect(peer)).await {
+        Ok(Ok(_)) => Some(started.elapsed()),
+        _ => None,
+    }
+}
+
+/// Stage-1 budget: long enough for a slow round trip, short enough to keep
+/// the filter cheap. Pure, tested.
+fn prefilter_timeout(full: Duration) -> Duration {
+    full.div_f32(2.0).clamp(Duration::from_secs(2), Duration::from_secs(5))
+}
+
+/// Inter-probe pacing (burst smoothing for hostile networks).
+/// `AETHER_PROBE_JITTER_MS` = max random delay per probe, 0 = unchanged.
+async fn probe_pacing() {
+    let max_ms: u64 = std::env::var("AETHER_PROBE_JITTER_MS")
+        .ok()
+        .and_then(|v| v.trim().parse().ok())
+        .unwrap_or(0);
+    if max_ms > 0 {
+        let ms = rand::rng().random_range(0..=max_ms);
+        if ms > 0 {
+            tokio::time::sleep(Duration::from_millis(ms)).await;
+        }
+    }
+}
+
+pub(crate) async fn paced_probe_start() {
+    probe_pacing().await;
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -660,48 +769,6 @@ mod tests {
                 MASQUE_PORTS.contains(&port),
                 "documented fallback port {port} should be scanned"
             );
-        }
-    }
-
-    async fn quic_answers(peer: SocketAddr, timeout: Duration) -> Option<Duration> {
-        let bind = if peer.is_ipv4() { "0.0.0.0:0" } else { "[::]:0" };
-        let sock = tokio::net::UdpSocket::bind(bind).await.ok()?;
-        sock.connect(peer).await.ok()?;
-        let local = sock.local_addr().ok()?;
-
-        let mut config = quiche::Config::new(quiche::PROTOCOL_VERSION).ok()?;
-        config.set_application_protos(&[b"h3"]).ok()?;
-        config.verify_peer(false);
-        config.set_max_idle_timeout(timeout.as_millis() as u64);
-        config.set_initial_max_data(1_000_000);
-        config.set_initial_max_stream_data_bidi_local(100_000);
-        config.set_initial_max_streams_bidi(4);
-
-        let mut scid = [0u8; 16];
-        rand::rng().fill(&mut scid[..]);
-        let scid = quiche::ConnectionId::from_ref(&scid);
-
-        let sni = crate::consts::CONNECT_SNI;
-        let mut conn = quiche::connect(Some(sni), &scid, local, peer, &mut config).ok()?;
-
-        let mut out = [0u8; 1350];
-        let (written, _) = conn.send(&mut out).ok()?;
-
-        let started = Instant::now();
-        sock.send(&out[..written]).await.ok()?;
-
-        let mut buf = [0u8; 1500];
-        match tokio::time::timeout(timeout, sock.recv(&mut buf)).await {
-            Ok(Ok(read)) if read > 0 => Some(started.elapsed()),
-            _ => None,
-        }
-    }
-
-    async fn tcp_answers(peer: SocketAddr, timeout: Duration) -> Option<Duration> {
-        let started = Instant::now();
-        match tokio::time::timeout(timeout, tokio::net::TcpStream::connect(peer)).await {
-            Ok(Ok(_)) => Some(started.elapsed()),
-            _ => None,
         }
     }
 
@@ -880,6 +947,127 @@ mod tests {
             }
         }
         println!();
+    }
+
+    #[test]
+    fn anchors_still_lead_in_position_with_spread_ports() {
+        let st = ScanMode::Turbo.strategy();
+        let ports = [443u16, 500, 1701];
+        let out = build_candidates(&st, &ports, IpScan::V4);
+        for (idx, seed) in MASQUE_SEEDS.iter().enumerate() {
+            let ip = IpAddr::V4(seed.parse().expect("seed"));
+            assert_eq!(out[idx].0, ip, "anchor {ip} must keep its lead position");
+            assert_eq!(
+                out[idx].1,
+                ports[idx % ports.len()],
+                "anchor ports must rotate, not stack on 443"
+            );
+        }
+        let head: HashSet<u16> = out[..ports.len()].iter().map(|(_, p)| *p).collect();
+        assert_eq!(head.len(), ports.len(), "scan head must spread across ports");
+    }
+
+    #[test]
+    fn pool_hosts_get_a_rotated_alternate_port_up_front() {
+        let st = ScanMode::Turbo.strategy();
+        let ports = [443u16, 500, 1701];
+        let out = build_candidates(&st, &ports, IpScan::V4);
+        // First pool IP sits right after the anchors.
+        let pool_ip = out[MASQUE_SEEDS.len()].0;
+        let hits: Vec<u16> = out
+            .iter()
+            .filter(|(ip, _)| *ip == pool_ip)
+            .map(|(_, p)| *p)
+            .collect();
+        assert!(hits.contains(&443), "pool host must still be tried on 443");
+        assert!(
+            hits.iter().any(|p| *p != 443),
+            "pool host {pool_ip} must also be tried off-primary without waiting for the tail"
+        );
+        let first_alt = out
+            .iter()
+            .position(|(ip, p)| *ip == pool_ip && *p != 443)
+            .unwrap();
+        assert!(
+            first_alt < 2 * (MASQUE_SEEDS.len() + 64),
+            "alternate-port attempt must land in the first two waves"
+        );
+    }
+
+    #[test]
+    fn candidate_list_has_no_duplicates() {
+        let st = ScanMode::Balanced.strategy();
+        let out = build_candidates(&st, MASQUE_PORTS, IpScan::V4);
+        let mut seen = HashSet::new();
+        for c in &out {
+            assert!(seen.insert(*c), "duplicate candidate {c:?}");
+        }
+    }
+
+    #[test]
+    fn empty_port_list_falls_back_to_443() {
+        let st = ScanMode::Turbo.strategy();
+        let out = build_candidates(&st, &[], IpScan::V4);
+        assert!(!out.is_empty());
+        assert!(out.iter().all(|(_, p)| *p == 443));
+    }
+
+    #[test]
+    fn prefilter_budget_covers_slow_round_trips_but_stays_cheap() {
+        assert_eq!(prefilter_timeout(Duration::from_secs(6)), Duration::from_secs(3));
+        assert_eq!(prefilter_timeout(Duration::from_secs(5)), Duration::from_millis(2500));
+        // Never shorter than one slow RTT, never pricier than a quick check.
+        assert_eq!(prefilter_timeout(Duration::from_secs(60)), Duration::from_secs(5));
+        assert_eq!(prefilter_timeout(Duration::from_millis(500)), Duration::from_secs(2));
+    }
+
+    #[tokio::test]
+    async fn pacing_defaults_to_zero_delay() {
+        std::env::remove_var("AETHER_PROBE_JITTER_MS");
+        let start = Instant::now();
+        paced_probe_start().await;
+        assert!(start.elapsed() < Duration::from_secs(1));
+        std::env::set_var("AETHER_PROBE_JITTER_MS", "bogus");
+        paced_probe_start().await;
+        std::env::remove_var("AETHER_PROBE_JITTER_MS");
+    }
+
+    #[tokio::test]
+    async fn cheap_filter_passes_a_talker_and_drops_silence() {
+        // UDP responder on loopback: any reply counts as "someone lives here".
+        let udp = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let udp_addr = udp.local_addr().unwrap();
+        tokio::spawn(async move {
+            let mut buf = [0u8; 1500];
+            if let Ok((n, peer)) = udp.recv_from(&mut buf).await {
+                let _ = udp.send_to(&buf[..n.min(64)], peer).await;
+            }
+        });
+        assert!(
+            cheap_initial_reply(udp_addr, false, Duration::from_secs(3)).await,
+            "a replying UDP socket must pass the filter"
+        );
+        // TCP listener on loopback for the H2-mode branch.
+        let tcp = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let tcp_addr = tcp.local_addr().unwrap();
+        tokio::spawn(async move {
+            let _ = tcp.accept().await;
+        });
+        assert!(
+            cheap_initial_reply(tcp_addr, true, Duration::from_secs(3)).await,
+            "an open TCP port must pass the filter"
+        );
+        // Closed ports stay silent on loopback: ICMP refused / RST.
+        let dead_udp: SocketAddr = "127.0.0.1:1".parse().unwrap();
+        assert!(
+            !cheap_initial_reply(dead_udp, false, Duration::from_secs(2)).await,
+            "a silent UDP port must be filtered out"
+        );
+        let dead_tcp: SocketAddr = "127.0.0.1:1".parse().unwrap();
+        assert!(
+            !cheap_initial_reply(dead_tcp, true, Duration::from_secs(2)).await,
+            "a closed TCP port must be filtered out"
+        );
     }
 
     #[test]

--- a/aether/src/wg_prober.rs
+++ b/aether/src/wg_prober.rs
@@ -289,6 +289,7 @@ async fn verify_one_wg(
     timeout: Duration,
     ironclad: bool,
 ) -> Option<WgProbeResult> {
+    crate::prober::paced_probe_start().await;
     let peer = SocketAddr::new(ip, port);
 
     let (rtt, session) = match wireguard::verify_endpoint_keep_session(


### PR DESCRIPTION
## What

Four bounded improvements to the endpoint scanners. No CLI changes, fully backward compatible.

### 1. Recent-winners ring (`lastconn.rs`, `lib.rs`)
`LastConnection` now also stores a most-recent-first ring of working endpoints (`recent`, cap 8, `#[serde(default)]` — old files load unchanged). Both `run_masque` and `run_wireguard` try the ring newest-first before any sweep, so a reconnect usually completes in seconds instead of falling into a full scan after a single stale cached peer.

### 2. MASQUE port waves (`prober.rs::build_candidates`)
Previously the pool of sampled CIDR hosts was only probed on the primary port (443); the multi-port loop covered the 8 seeds only. The WG scanner already rotated ports for its pool (`ports[(idx + wave) % port_count]`), so this brings MASQUE to the same shape: wave 0 rotates ports across the ordered list, wave 1 covers each address once more on its next rotated port. Anchors keep their lead positions plus full multi-port tail coverage, as before. Tested: `anchors_still_lead_in_position_with_spread_ports`, `pool_hosts_get_a_rotated_alternate_port_up_front`, `candidate_list_has_no_duplicates`.

### 3. Cheap reachability pre-filter (`prober.rs::verify_one`)
Non-ironclad probes send one bare QUIC Initial (TCP SYN when the HTTP/2 transport is enabled) and skip the full crypto handshake when the host stays silent. A real MASQUE edge must answer an Initial (RFC 9000), and the codebase's own range-characterization test already treats any Initial reply as liveness. Ironclad mode is untouched (no pre-filter, full HTTP request per candidate). Budget: `prefilter_timeout` = half the per-probe timeout, clamped to 2–5 s.

### 4. `AETHER_PROBE_JITTER_MS`
Optional max per-probe random start delay (default 0 = unchanged behavior) to smooth scan bursts on networks that rate-limit scanners. Documented in `--help`.

## Not changed
Strategy deadlines, concurrency caps, CIDR/seed lists, candidate head ordering for the scan log, ironclad flow, file formats (additive serde fields only).

## Verification

- `cargo test`: 269 passed / 0 failed (11 new offline unit tests; the live-network characterization test stays `#[ignore]`d)
- `cargo clippy`: clean on all touched files
- `cargo build --release`: clean (macOS arm64)
- Live end-to-end check of the ring fast path with loopback-only peers: log shows newest-first iteration and clean fallback to a fresh scan; no production traffic involved